### PR TITLE
Catch the right exception. Fixes #11

### DIFF
--- a/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
+++ b/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
@@ -16,9 +16,9 @@
 package io.micronaut.views.freemarker;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import freemarker.core.ParseException;
 import freemarker.template.*;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.cli.exceptions.ParseException;
 import io.micronaut.core.io.Writable;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.http.MediaType;

--- a/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerController.groovy
+++ b/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerController.groovy
@@ -78,4 +78,9 @@ class FreemarkerController {
     HttpResponse nullBody() {
         HttpResponse.ok()
     }
+
+    @Get("/invalid")
+    ModelAndView invalid() {
+        return new ModelAndView("/invalid", Collections.emptyMap())
+    }
 }

--- a/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerViewRendererSpec.groovy
+++ b/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerViewRendererSpec.groovy
@@ -188,4 +188,15 @@ class FreemarkerViewRendererSpec extends Specification {
         body
         rsp.body().contains("<h1>You are not logged in</h1>")
     }
+
+    def "invoking /freemarker/invalid returns error"() {
+        when:
+        client.toBlocking().exchange('/freemarker/invalid', String)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+
+        and:
+        e.status == HttpStatus.INTERNAL_SERVER_ERROR
+    }
 }

--- a/views-freemarker/src/test/resources/views/invalid.ftl
+++ b/views-freemarker/src/test/resources/views/invalid.ftl
@@ -1,0 +1,23 @@
+<#--
+
+    Copyright 2017-2019 original authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE html>
+<html>
+<body>
+<#if false>
+</body>
+</html>


### PR DESCRIPTION
With this PR, when there is an error in a view, the right error message is displayed:

```
Caused by: freemarker.core.ParseException: Syntax error in template "invalid.ftl" in line 23, column 8:
Unexpected end of file reached. You have an unclosed #if.
```