### PR TITLE
build: bump up freemarker from 2.3.30 to 2.3.31

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ groovyVersion=3.0.4
 spockVersion=2.0-M3-groovy-3.0
 
 snakeYamlVersion=1.27
-freemarkerVersion=2.3.30
+freemarkerVersion=2.3.31
 handlebarsVersion=4.2.0
 thymeleafVersion=3.0.12.RELEASE
 velocityVersion=2.2


### PR DESCRIPTION
[Freemarker 2.3.31 - Release notes](https://freemarker.apache.org/docs/versions_2_3_31.html)