### PR TITLE
build: bump up soy to 2021-02-01

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ handlebarsVersion=4.2.0
 thymeleafVersion=3.0.12.RELEASE
 velocityVersion=2.2
 rockerVersion=1.3.0
-soyVersion=2020-08-24
+soyVersion=2021-02-01
 pebbleVersion=3.1.4
 
 title=Micronaut Views


### PR DESCRIPTION
Release notes don't say anything about what's new. [2021-02-01](https://github.com/google/closure-templates/releases/tag/release-2021-02-01). I don't think there are breaking changes based on the [commits list](https://github.com/google/closure-templates/compare/release-2021-02-01...master)