### PR TITLE
Bean model view support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See the [Snapshot Documentation](https://micronaut-projects.github.io/micronaut-
 
 ## Snapshots and Releases
 
-Snaphots are automatically published to JFrog OSS using [Github Actions](https://github.com/micronaut-projects/micronaut-views/actions).
+Snapshots are automatically published to JFrog OSS using [Github Actions](https://github.com/micronaut-projects/micronaut-views/actions).
 
 See the documentation in the [Micronaut Docs](https://docs.micronaut.io/latest/guide/index.html#usingsnapshots) for how to configure your build to use snapshots.
 

--- a/test-suite/src/test/groovy/views/ModelAndViewSpec.groovy
+++ b/test-suite/src/test/groovy/views/ModelAndViewSpec.groovy
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package views
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.views.model.FruitsController
+import spock.lang.Specification
+
+class ModelAndViewSpec extends Specification {
+
+    def "a view model can be any object"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'spec.name'                                       : 'ViewModelProcessorSpec',
+                'micronaut.views.soy.enabled'                     : false,
+                'micronaut.security.views-model-decorator.enabled': false,
+        ]) as EmbeddedServer
+        HttpClient httpClient = HttpClient.create(embeddedServer.URL)
+
+        expect:
+        embeddedServer.applicationContext.containsBean(FruitsController)
+
+        when:
+        HttpRequest request = HttpRequest.GET("/")
+        HttpResponse<String> response = httpClient.toBlocking().exchange(request, String)
+
+        then:
+        response.status() == HttpStatus.OK
+
+        when:
+        String html = response.body()
+        println "=" * 100
+        println "html -> " + html
+        println "=" * 100
+
+        then:
+        html
+
+        and:
+        html.contains('<h1>fruit: apple</h1>')
+
+        and:
+        html.contains('<h1>color: red</h1>')
+
+        cleanup:
+        httpClient.close()
+
+        and:
+        embeddedServer.close()
+    }
+
+    def "returning a null models equals a 404"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'spec.name'                                       : 'ViewModelProcessorSpec',
+                'micronaut.views.soy.enabled'                     : false,
+                'micronaut.security.views-model-decorator.enabled': false,
+        ]) as EmbeddedServer
+        HttpClient httpClient = HttpClient.create(embeddedServer.URL, )
+
+        expect:
+        embeddedServer.applicationContext.containsBean(FruitsController)
+
+        when:
+        HttpRequest request = HttpRequest.GET("/null")
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        thrown(HttpClientResponseException)
+
+        cleanup:
+        httpClient.close()
+
+        and:
+        embeddedServer.close()
+    }
+
+    def "a view model can be a map"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'spec.name'                                       : 'ViewModelProcessorSpec',
+                'micronaut.views.soy.enabled'                     : false,
+                'micronaut.security.views-model-decorator.enabled': false,
+        ]) as EmbeddedServer
+        HttpClient httpClient = HttpClient.create(embeddedServer.URL)
+
+        expect:
+        embeddedServer.applicationContext.containsBean(FruitsController)
+
+        when:
+        HttpRequest request = HttpRequest.GET("/map")
+        HttpResponse<String> response = httpClient.toBlocking().exchange(request, String)
+
+        then:
+        response.status() == HttpStatus.OK
+
+        when:
+        String html = response.body()
+        println "=" * 100
+        println "html -> " + html
+        println "=" * 100
+
+        then:
+        html
+
+        and:
+        html.contains('<h1>fruit: orange</h1>')
+
+        and:
+        html.contains('<h1>color: orange</h1>')
+
+        cleanup:
+        httpClient.close()
+
+        and:
+        embeddedServer.close()
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/views/model/FruitsController.java
+++ b/test-suite/src/test/java/io/micronaut/views/model/FruitsController.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.views.model;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
+import io.micronaut.views.View;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.TreeMap;
+
+@Secured(SecurityRule.IS_ANONYMOUS)
+@Requires(property = "spec.name", value = "ViewModelProcessorSpec")
+@Controller()
+public class FruitsController {
+
+    @View("fruits")
+    @Get
+    public Fruit index() {
+        return new Fruit("apple", "red");
+    }
+
+    @View("fruits")
+    @Get("/null")
+    public Object nullModel() {
+        return null;
+    }
+
+    @View("fruits")
+    @Get("/map")
+    public Map<String, Object> collectionModel() {
+        Map<String, Object> context = new TreeMap<>();
+        context.put("fruit", new Fruit("orange", "orange"));
+        return context;
+    }
+
+    public static class Fruit {
+        private final String name;
+        private final String color;
+
+        public Fruit(String name, String color) {
+            this.name = name;
+            this.color = color;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getColor() {
+            return color;
+        }
+    }
+}

--- a/test-suite/src/test/resources/views/fruits.vm
+++ b/test-suite/src/test/resources/views/fruits.vm
@@ -1,0 +1,33 @@
+#* @vtlvariable name="fruit" type="io.micronaut.views.model.FruitsController.Fruit" *#
+#*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *#
+##tag::html[]
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Fruits</title>
+</head>
+<body>
+<h1>fruit: $name</h1>
+<h1>color: $color</h1>
+
+## this is the same as above
+<h1>fruit: $fruit.getName()</h1>
+<h1>color: $fruit.getColor()</h1>
+
+</body>
+</html>
+##end::html[]


### PR DESCRIPTION
* Minimal refactoring focused on backwards compatibility preserving all current interfaces but adding the ability to send bean models to a view
* ModelViewProcessors are not applied to non-map like models due to its strict Map<String, Object> interface. We should consider revisiting this in favor of a ```<T>``` interface for v3
* ViewFilter bypasses the view rendering logic in non 2xx responses

Fixes #179 