### PR TITLE
BREAKING CHANGE: typed ViewsRenderer

### DIFF
--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -4,6 +4,8 @@ This section outlines the breaking changes done in major versions of Micronaut V
 
 * api:views.model.ViewModelProcessor[] no longer assumes a `Map<String,Object>` model and must be typed to the exact type of the model you would like to process.
 
+* api:views.model.ViewsRenderer[] are now typed. Moreover, provided `ViewsRenderer` don't specify `@Produces(MediaType.TEXT_HTML)` and responses content type respect the content type defined for the route.
+
 == 2.0.0
 
 * The `micronaut-views` dependency is no longer published. Replace the dependency with the one specific to the view implementation being used.

--- a/test-suite/src/test/groovy/views/NonHTMLViewRendererSpec.groovy
+++ b/test-suite/src/test/groovy/views/NonHTMLViewRendererSpec.groovy
@@ -1,0 +1,209 @@
+package views
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.core.io.Writable
+import io.micronaut.core.order.Ordered
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.views.View
+import io.micronaut.views.ViewsRenderer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import javax.inject.Singleton
+import java.util.stream.Collectors
+
+class NonHTMLViewRendererSpec extends Specification {
+
+    @AutoCleanup
+    @Shared
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'micronaut.security.enabled': false,
+            'spec.name': 'CsvViewRendererSpec',
+            'micronaut.views.soy.enabled': false,
+    ])
+
+    @AutoCleanup
+    @Shared
+    HttpClient httpClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.URL)
+
+    @Shared
+    BlockingHttpClient client = httpClient.toBlocking()
+
+    void "A default HTML ViewsRenderer - e.g. Velocity - is picked if not typed rendered for media type is found"() {
+        when:
+        String html = client.retrieve(HttpRequest.GET('/books').accept(MediaType.TEXT_HTML), String)
+
+        then:
+        noExceptionThrown()
+        html.contains('<h2>#books: 3</h2>')
+    }
+
+    void "If no view resolved, it renders as json"() {
+        when:
+        String json = client.retrieve(HttpRequest.GET('/books').accept(MediaType.APPLICATION_JSON), String)
+
+        then:
+        noExceptionThrown()
+        json.startsWith('{"books":')
+        json.contains('{"isbn":"1491950358","name":"Building Microservices"}')
+        json.contains('{"isbn":"1680502395","name":"Release It!"}')
+        json.contains('{"isbn":"0321601912","name":"Continuous Delivery"}')
+    }
+
+    void "You can register ViewsRenderer for media types other than HTML"() {
+        when:
+        String csv = client.retrieve(HttpRequest.GET('/books').accept(MediaType.TEXT_CSV), String)
+
+        then:
+        noExceptionThrown()
+        csv == '''\
+1491950358,Building Microservices
+1680502395,Release It!
+0321601912,Continuous Delivery'''
+
+        when:
+        String xml = client.retrieve(HttpRequest.GET('/books').accept(MediaType.TEXT_XML), String)
+
+        then:
+        noExceptionThrown()
+        xml == '''\
+<books>
+<book><isbn>1491950358</isbn><name>Building Microservices</name></book>
+<book><isbn>1680502395</isbn><name>Release It!</name></book>
+<book><isbn>0321601912</isbn><name>Continuous Delivery</name></book>
+</books>'''
+    }
+
+    @Produces(MediaType.TEXT_XML)
+    @Requires(property = "spec.name", value = "CsvViewRendererSpec")
+    @Singleton
+    static class XmlViewRenderer implements ViewsRenderer<Library> {
+        @Override
+        Writable render(@NonNull String viewName, @Nullable Library data) {
+            new Writable() {
+                @Override
+                void writeTo(Writer out) throws IOException {
+                    out.write("<books>\n" + String.join("\n", data.getBooks().stream()
+                            .map(b -> "<book><isbn>" + b.getIsbn() + "</isbn><name>" + b.getName() +  "</name></book>" )
+                            .collect(Collectors.toList())) + "\n</books>")
+                }
+            }
+        }
+
+        @Override
+        boolean exists(@NonNull String viewName) {
+            return "books".equalsIgnoreCase(viewName)
+        }
+    }
+
+    @Produces(MediaType.TEXT_CSV)
+    @Requires(property = "spec.name", value = "CsvViewRendererSpec")
+    @Singleton
+    static class SingleBookViewRenderer implements ViewsRenderer<Book> {
+        // this renderer should not be used because it specifies a different type
+
+        @Override
+        Writable render(@NonNull String viewName, @Nullable Book data) {
+            new Writable() {
+                @Override
+                void writeTo(Writer out) throws IOException {
+                    out.write("FAIL")
+                }
+            }
+        }
+
+        @Override
+        boolean exists(@NonNull String viewName) {
+            return true
+        }
+
+        @Override
+        int getOrder() {
+            HIGHEST_PRECEDENCE
+        }
+    }
+
+    @Produces(MediaType.TEXT_CSV)
+    @Requires(property = "spec.name", value = "CsvViewRendererSpec")
+    @Singleton
+    static class CsvViewRenderer implements ViewsRenderer<Library> {
+        @Override
+        Writable render(@NonNull String viewName, @Nullable Library data) {
+            new Writable() {
+                @Override
+                void writeTo(Writer out) throws IOException {
+                    out.write(String.join("\n", data.getBooks().stream()
+                            .map(b -> b.getIsbn() + "," + b.getName())
+                            .collect(Collectors.toList())))
+                }
+            }
+        }
+
+        @Override
+        boolean exists(@NonNull String viewName) {
+            return "books".equalsIgnoreCase(viewName)
+        }
+    }
+
+    @Introspected
+    static class Book {
+        String isbn
+        String name
+        Book(String isbn, String name) {
+            this.isbn = isbn
+            this.name = name
+        }
+    }
+
+
+    @Introspected
+    static class Library {
+        List<Book> books
+        Library(List<Book> books) {
+            this.books = books
+        }
+    }
+
+    @Requires(property = "spec.name", value = "CsvViewRendererSpec")
+    @Controller("/books")
+    static class BooksController {
+        static final Library books = new Library([new Book("1491950358", "Building Microservices"),
+         new Book("1680502395", "Release It!"),
+         new Book("0321601912", "Continuous Delivery")])
+
+        @View("books")
+        @Get(produces = MediaType.TEXT_CSV)
+        Library index() {
+            books
+        }
+
+        @Produces(MediaType.TEXT_HTML)
+        @View("books")
+        @Get
+        Library booksHtml() {
+            books
+        }
+
+        @Get
+        Library json() {
+            books
+        }
+
+        @View("books")
+        @Get(produces = MediaType.TEXT_XML)
+        Library booksXml() {
+            books
+        }
+    }
+}

--- a/test-suite/src/test/resources/views/books.vm
+++ b/test-suite/src/test/resources/views/books.vm
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Books</title>
+</head>
+<body>
+<h2>#books: $books.size()</h2>
+</body>
+</html>

--- a/views-core/src/main/java/io/micronaut/views/ViewsRenderer.java
+++ b/views-core/src/main/java/io/micronaut/views/ViewsRenderer.java
@@ -26,11 +26,11 @@ import java.util.Map;
 
 /**
  * Interface to be implemented by View Engines implementations.
- *
+ * @param <T> The model type
  * @author Sergio del Amo
  * @since 1.0
  */
-public interface ViewsRenderer extends Ordered {
+public interface ViewsRenderer<T> extends Ordered {
 
     /**
      * The extension separator.
@@ -42,7 +42,7 @@ public interface ViewsRenderer extends Ordered {
      * @param data     response body to render it with a view
      * @return A writable where the view will be written to.
      */
-    @NonNull Writable render(@NonNull String viewName, @Nullable Object data);
+    @NonNull Writable render(@NonNull String viewName, @Nullable T data);
 
     /**
      * @param viewName view name to be rendered
@@ -50,7 +50,7 @@ public interface ViewsRenderer extends Ordered {
      * @param request  HTTP request
      * @return A writable where the view will be written to.
      */
-    default @NonNull Writable render(@NonNull String viewName, @Nullable Object data,
+    default @NonNull Writable render(@NonNull String viewName, @Nullable T data,
             @NonNull HttpRequest<?> request) {
         return render(viewName, data);
     }
@@ -66,7 +66,7 @@ public interface ViewsRenderer extends Ordered {
      * @param data The data
      * @return The model
      */
-    default @NonNull Map<String, Object> modelOf(@Nullable Object data) {
+    default @NonNull Map<String, Object> modelOf(@Nullable T data) {
         if (data == null) {
             return new HashMap<>(0);
         }

--- a/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
+++ b/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
@@ -15,14 +15,15 @@
  */
 package io.micronaut.views.freemarker;
 
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import freemarker.template.MalformedTemplateNameException;
 import io.micronaut.core.annotation.NonNull;
 import freemarker.core.ParseException;
-import freemarker.template.*;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.io.Writable;
 import io.micronaut.core.util.ArgumentUtils;
-import io.micronaut.http.MediaType;
-import io.micronaut.http.annotation.Produces;
 import io.micronaut.views.ViewUtils;
 import io.micronaut.views.ViewsConfiguration;
 import io.micronaut.views.ViewsRenderer;
@@ -40,12 +41,12 @@ import java.util.Map;
  * @author Jerónimo López
  * @see <a href= "https://freemarker.apache.org/">freemarker.apache.org</a>
  * @since 1.1
+ * @param <T> The model type
  */
-@Produces(MediaType.TEXT_HTML)
 @Requires(property = FreemarkerViewsRendererConfigurationProperties.PREFIX + ".enabled", notEquals = "false")
 @Requires(classes = Configuration.class)
 @Singleton
-public class FreemarkerViewsRenderer implements ViewsRenderer {
+public class FreemarkerViewsRenderer<T> implements ViewsRenderer<T> {
 
     protected final ViewsConfiguration viewsConfiguration;
     protected final FreemarkerViewsRendererConfigurationProperties freemarkerMicronautConfiguration;
@@ -65,7 +66,7 @@ public class FreemarkerViewsRenderer implements ViewsRenderer {
 
     @NonNull
     @Override
-    public Writable render(@NonNull String viewName, @Nullable Object data) {
+    public Writable render(@NonNull String viewName, @Nullable T data) {
         ArgumentUtils.requireNonNull("viewName", viewName);
         return (writer) -> {
             Map<String, Object> context = modelOf(data);

--- a/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerController.groovy
+++ b/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerController.groovy
@@ -51,8 +51,8 @@ class FreemarkerController {
 
     @Produces(MediaType.TEXT_PLAIN)
     @View("home.ftl")
-    @Get("/viewWithNoViewRendererForProduces")
-    Person viewWithNoViewRendererForProduces() {
+    @Get("/plainText")
+    Person plainText() {
         new Person(loggedIn: true, username: 'sdelamo')
     }
 

--- a/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerViewRendererSpec.groovy
+++ b/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerViewRendererSpec.groovy
@@ -147,20 +147,22 @@ class FreemarkerViewRendererSpec extends Specification {
         rsp.body().contains("<h1>username: <span>sdelamo</span></h1>")
     }
 
-    def "invoking /freemarker/viewWithNoViewRendererForProduces skips view rendering since controller specifies a media type with no available ViewRenderer"() {
+    def "invoking /freemarker/plainText renders with template but sets content type to txt/plain"() {
         when:
-        HttpResponse<String> rsp = client.toBlocking().exchange('/freemarker/viewWithNoViewRendererForProduces', String)
+        HttpResponse<String> rsp = client.toBlocking().exchange('/freemarker/plainText', String)
 
         then:
         noExceptionThrown()
         rsp.status() == HttpStatus.OK
+        rsp.getHeaders().getContentType().isPresent()
+        rsp.getHeaders().getContentType().get() == MediaType.TEXT_PLAIN
 
         when:
         String body = rsp.body()
 
-        then: 'default JSON rendering is used since no bean ViewRenderer is available for text/csv media type'
+        then:
         body
-        rsp.body() == 'io.micronaut.docs.Person(sdelamo, true)'
+        rsp.body().contains("<h1>username: <span>sdelamo</span></h1>")
     }
 
     def "invoking /freemarker/bogus returns 500 if you attempt to render a template which does not exist"() {

--- a/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRenderer.java
+++ b/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRenderer.java
@@ -24,8 +24,6 @@ import io.micronaut.core.io.Writable;
 import io.micronaut.core.io.scan.ClassPathResourceLoader;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.util.ArgumentUtils;
-import io.micronaut.http.MediaType;
-import io.micronaut.http.annotation.Produces;
 import io.micronaut.views.ViewUtils;
 import io.micronaut.views.ViewsConfiguration;
 import io.micronaut.views.ViewsRenderer;
@@ -40,12 +38,12 @@ import jakarta.inject.Singleton;
  * @author Sergio del Amo
  * @see <a href="https://jknack.github.io/handlebars.java/">https://jknack.github.io/handlebars.java/</a>
  * @since 1.0
+ * @param <T> The model type
  */
-@Produces(MediaType.TEXT_HTML)
 @Requires(property = HandlebarsViewsRendererConfigurationProperties.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
 @Requires(classes = Handlebars.class)
 @Singleton
-public class HandlebarsViewsRenderer implements ViewsRenderer {
+public class HandlebarsViewsRenderer<T> implements ViewsRenderer<T> {
 
     protected final ViewsConfiguration viewsConfiguration;
     protected final ResourceLoader resourceLoader;
@@ -73,7 +71,7 @@ public class HandlebarsViewsRenderer implements ViewsRenderer {
 
     @NonNull
     @Override
-    public Writable render(@NonNull String viewName, @Nullable Object data) {
+    public Writable render(@NonNull String viewName, @Nullable T data) {
         ArgumentUtils.requireNonNull("viewName", viewName);
         return (writer) -> {
             String location = viewLocation(viewName);

--- a/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleViewsRenderer.java
+++ b/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleViewsRenderer.java
@@ -21,8 +21,6 @@ import com.mitchellbosecke.pebble.PebbleEngine;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.io.Writable;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.http.MediaType;
-import io.micronaut.http.annotation.Produces;
 import io.micronaut.views.ViewUtils;
 import io.micronaut.views.ViewsRenderer;
 
@@ -32,12 +30,12 @@ import io.micronaut.views.ViewsRenderer;
  * @author Ecmel Ercan
  * @see <a href="https://pebbletemplates.io/">https://pebbletemplates.io/</a>
  * @since 2.2.0
+ * @param <T> The model type
  */
 @Singleton
-@Produces(MediaType.TEXT_HTML)
 @Requires(property = PebbleConfigurationProperties.ENABLED, notEquals = StringUtils.FALSE)
 @Requires(classes = PebbleEngine.class)
-public class PebbleViewsRenderer implements ViewsRenderer {
+public class PebbleViewsRenderer<T> implements ViewsRenderer<T> {
     
     private final String extension;
     private final PebbleEngine engine;
@@ -49,7 +47,7 @@ public class PebbleViewsRenderer implements ViewsRenderer {
     }
 
     @Override
-    public Writable render(String name, Object data) {
+    public Writable render(String name, T data) {
         return (writer) -> engine.getTemplate(ViewUtils.normalizeFile(name, extension)).evaluate(writer, modelOf(data));
     }
 

--- a/views-rocker/src/main/java/io/micronaut/views/rocker/RockerViewsRenderer.java
+++ b/views-rocker/src/main/java/io/micronaut/views/rocker/RockerViewsRenderer.java
@@ -18,8 +18,6 @@ package io.micronaut.views.rocker;
 import com.fizzed.rocker.BindableRockerModel;
 import io.micronaut.core.io.Writable;
 import io.micronaut.core.util.ArgumentUtils;
-import io.micronaut.http.MediaType;
-import io.micronaut.http.annotation.Produces;
 import io.micronaut.views.ViewsConfiguration;
 import io.micronaut.views.ViewsRenderer;
 import io.micronaut.core.annotation.NonNull;
@@ -33,10 +31,10 @@ import java.util.Map;
  *
  * @author Sam Adams
  * @since 1.3.2
+ * @param <T> The model type
  */
-@Produces(MediaType.TEXT_HTML)
 @Singleton
-public class RockerViewsRenderer implements ViewsRenderer {
+public class RockerViewsRenderer<T> implements ViewsRenderer<T> {
 
     protected final RockerEngine rockerEngine;
     protected final ViewsConfiguration viewsConfiguration;
@@ -60,7 +58,7 @@ public class RockerViewsRenderer implements ViewsRenderer {
 
     @NonNull
     @Override
-    public Writable render(@NonNull String view, @Nullable Object data) {
+    public Writable render(@NonNull String view, @Nullable T data) {
         ArgumentUtils.requireNonNull("view", view);
 
         Map<String, Object> context = modelOf(data);

--- a/views-rocker/src/test/groovy/io/micronaut/docs/RockerController.groovy
+++ b/views-rocker/src/test/groovy/io/micronaut/docs/RockerController.groovy
@@ -60,8 +60,8 @@ class RockerController {
 
     @Produces(MediaType.TEXT_PLAIN)
     @View("home.rocker.html")
-    @Get("/viewWithNoViewRendererForProduces")
-    Person viewWithNoViewRendererForProduces() {
+    @Get("/plainText")
+    Person plainText() {
         new Person(loggedIn: true, username: 'sdelamo')
     }
 

--- a/views-rocker/src/test/groovy/io/micronaut/docs/RockerViewRendererSpec.groovy
+++ b/views-rocker/src/test/groovy/io/micronaut/docs/RockerViewRendererSpec.groovy
@@ -150,9 +150,9 @@ class RockerViewRendererSpec extends Specification {
         rsp.body().contains("<h1>username: <span>sdelamo</span></h1>")
     }
 
-    def "invoking /rocker/viewWithNoViewRendererForProduces skips view rendering since controller specifies a media type with no available ViewRenderer"() {
+    def "invoking /rocker/plainText renders with template but sets content type to txt/plain"() {
         when:
-        HttpResponse<String> rsp = client.toBlocking().exchange('/rocker/viewWithNoViewRendererForProduces', String)
+        HttpResponse<String> rsp = client.toBlocking().exchange('/rocker/plainText', String)
 
         then:
         noExceptionThrown()
@@ -161,9 +161,11 @@ class RockerViewRendererSpec extends Specification {
         when:
         String body = rsp.body()
 
-        then: 'default JSON rendering is used since no bean ViewRenderer is available for text/csv media type'
+        then:
         body
-        rsp.body() == 'io.micronaut.docs.Person(sdelamo, true)'
+        rsp.body().contains("<h1>username: <span>sdelamo</span></h1>")
+        rsp.getHeaders().getContentType().isPresent()
+        rsp.getHeaders().getContentType().get() == MediaType.TEXT_PLAIN
     }
 
     def "invoking /rocker/bogus returns 500 if you attempt to render a template which does not exist"() {

--- a/views-soy/src/main/java/io/micronaut/views/soy/SoySauceViewsRenderer.java
+++ b/views-soy/src/main/java/io/micronaut/views/soy/SoySauceViewsRenderer.java
@@ -26,8 +26,6 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.io.Writable;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.http.HttpRequest;
-import io.micronaut.http.MediaType;
-import io.micronaut.http.annotation.Produces;
 import io.micronaut.views.ViewsConfiguration;
 import io.micronaut.views.ViewsRenderer;
 import io.micronaut.views.csp.CspConfiguration;
@@ -51,12 +49,12 @@ import java.util.concurrent.ExecutionException;
  *
  * @author Sam Gammon (sam@bloombox.io)
  * @since 1.2.1
+ * @param <T> The model type
  */
-@Produces(MediaType.TEXT_HTML)
 @Requires(classes = SoySauce.class)
 @Singleton
 @SuppressWarnings({"WeakerAccess", "UnstableApiUsage"})
-public class SoySauceViewsRenderer implements ViewsRenderer {
+public class SoySauceViewsRenderer<T> implements ViewsRenderer<T> {
 
   private static final Logger LOG = LoggerFactory.getLogger(SoySauceViewsRenderer.class);
   private static final String INJECTED_NONCE_PROPERTY = "csp_nonce";
@@ -102,7 +100,7 @@ public class SoySauceViewsRenderer implements ViewsRenderer {
    * @return A writable where the view will be written to.
    */
   @NonNull
-  public Writable render(@NonNull String viewName, @Nullable Object data) {
+  public Writable render(@NonNull String viewName, @Nullable T data) {
     return render(viewName, data, null);
   }
 
@@ -114,7 +112,7 @@ public class SoySauceViewsRenderer implements ViewsRenderer {
    */
   @NonNull
   @Override
-  public Writable render(@NonNull String viewName, @Nullable Object data, @NonNull HttpRequest<?> request) {
+  public Writable render(@NonNull String viewName, @Nullable T data, @NonNull HttpRequest<?> request) {
     ArgumentUtils.requireNonNull("viewName", viewName);
 
     Map<String, Object> ijOverlay = new HashMap<>(1);

--- a/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRenderer.java
+++ b/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRenderer.java
@@ -17,8 +17,6 @@ package io.micronaut.views.velocity;
 
 import io.micronaut.core.io.Writable;
 import io.micronaut.core.util.ArgumentUtils;
-import io.micronaut.http.MediaType;
-import io.micronaut.http.annotation.Produces;
 import io.micronaut.views.ViewUtils;
 import io.micronaut.views.ViewsConfiguration;
 import io.micronaut.views.ViewsRenderer;
@@ -45,10 +43,10 @@ import java.util.Properties;
  *
  * @see <a href="https://velocity.apache.org">https://velocity.apache.org</a>
  * @since 1.0
+ * @param <T> The model type
  */
-@Produces(MediaType.TEXT_HTML)
 @Singleton
-public class VelocityViewsRenderer implements ViewsRenderer {
+public class VelocityViewsRenderer<T> implements ViewsRenderer<T> {
 
     protected final VelocityEngine velocityEngine;
     protected final ViewsConfiguration viewsConfiguration;
@@ -72,7 +70,7 @@ public class VelocityViewsRenderer implements ViewsRenderer {
 
     @NonNull
     @Override
-    public Writable render(@NonNull String view, @Nullable Object data) {
+    public Writable render(@NonNull String view, @Nullable T data) {
         ArgumentUtils.requireNonNull("view", view);
         return (writer) -> {
             Map<String, Object> context = modelOf(data);

--- a/views-velocity/src/test/groovy/io/micronaut/docs/VelocityController.groovy
+++ b/views-velocity/src/test/groovy/io/micronaut/docs/VelocityController.groovy
@@ -51,8 +51,8 @@ class VelocityController {
 
     @Produces(MediaType.TEXT_PLAIN)
     @View("home.vm")
-    @Get("/viewWithNoViewRendererForProduces")
-    Person viewWithNoViewRendererForProduces() {
+    @Get("/plainText")
+    Person plainText() {
         new Person(loggedIn: true, username: 'sdelamo')
     }
 

--- a/views-velocity/src/test/groovy/io/micronaut/docs/VelocityViewRendererSpec.groovy
+++ b/views-velocity/src/test/groovy/io/micronaut/docs/VelocityViewRendererSpec.groovy
@@ -134,20 +134,22 @@ class VelocityViewRendererSpec extends Specification {
         rsp.body().contains("<h1>username: <span>sdelamo</span></h1>")
     }
 
-    def "invoking /velocity/viewWithNoViewRendererForProduces skips view rendering since controller specifies a media type with no available ViewRenderer"() {
+    def "invoking /velocity/plainText renders with template but sets content type to txt/plain"() {
         when:
-        HttpResponse<String> rsp = client.toBlocking().exchange('/velocity/viewWithNoViewRendererForProduces', String)
+        HttpResponse<String> rsp = client.toBlocking().exchange('/velocity/plainText', String)
 
         then:
         noExceptionThrown()
         rsp.status() == HttpStatus.OK
+        rsp.getHeaders().getContentType().isPresent()
+        rsp.getHeaders().getContentType().get() == MediaType.TEXT_PLAIN
 
         when:
         String body = rsp.body()
 
-        then: 'default JSON rendering is used since no bean ViewRenderer is available for text/csv media type'
+        then:
         body
-        rsp.body() == 'io.micronaut.docs.Person(sdelamo, true)'
+        body.contains("<h1>username: <span>sdelamo</span></h1>")
     }
 
     def "invoking /velocity/bogus returns 404 if you attempt to render a template which does not exist"() {


### PR DESCRIPTION
- Removes the @Produces(MediaType.TEXT_HTML) annotation from ViewsRenderer

Close: https://github.com/micronaut-projects/micronaut-views/issues/167

Close: https://github.com/micronaut-projects/micronaut-views/issues/159