### PR TITLE
fix dot handling in normalizeFile

### DIFF
--- a/views-core/src/main/java/io/micronaut/views/ViewUtils.java
+++ b/views-core/src/main/java/io/micronaut/views/ViewUtils.java
@@ -87,8 +87,10 @@ public class ViewUtils {
         if (path.startsWith("/")) {
             path = path.substring(1);
         }
-        if (extension != null && !extension.startsWith(".")) {
-            extension = "." + extension;
+        if (extension != null) {
+            if (!extension.startsWith(".")) {
+                extension = "." + extension;
+            }
             if (path.endsWith(extension)) {
                 int idx = path.indexOf(extension);
                 path = path.substring(0, idx);

--- a/views-core/src/test/groovy/io/micronaut/views/ViewUtilsSpec.groovy
+++ b/views-core/src/test/groovy/io/micronaut/views/ViewUtilsSpec.groovy
@@ -4,18 +4,15 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class ViewUtilsSpec extends Specification {
-    @Unroll
+    @Unroll("ViewsUtils.normalizedPath(#path,#extension) == #expected")
     def "normalizeFile handles extensions with and without ."(path, extension, expected) {
-        when:
-        def actual = ViewUtils.normalizeFile(path, extension)
-
-        then:
-        actual == expected
+        expect:
+        expected == ViewUtils.normalizeFile(path, extension)
 
         where:
-        path | extension | expected
-        'home.xyz' | null | 'home.xyz'
-        'home.xyz' | 'xyz' | 'home'
-        'home.xyz' | '.xyz' | 'home'
+        path       | extension || expected
+        'home.xyz' | null      || 'home.xyz'
+        'home.xyz' | 'xyz'     || 'home'
+        'home.xyz' | '.xyz'    || 'home'
     }
 }

--- a/views-core/src/test/groovy/io/micronaut/views/ViewUtilsSpec.groovy
+++ b/views-core/src/test/groovy/io/micronaut/views/ViewUtilsSpec.groovy
@@ -1,8 +1,10 @@
 package io.micronaut.views
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class ViewUtilsSpec extends Specification {
+    @Unroll
     def "normalizeFile handles extensions with and without ."(path, extension, expected) {
         when:
         def actual = ViewUtils.normalizeFile(path, extension)

--- a/views-core/src/test/groovy/io/micronaut/views/ViewUtilsSpec.groovy
+++ b/views-core/src/test/groovy/io/micronaut/views/ViewUtilsSpec.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.views
+
+import spock.lang.Specification
+
+class ViewUtilsSpec extends Specification {
+    def "normalizeFile handles extensions with and without ."(path, extension, expected) {
+        when:
+        def actual = ViewUtils.normalizeFile(path, extension)
+
+        then:
+        actual == expected
+
+        where:
+        path | extension | expected
+        'home.xyz' | null | 'home.xyz'
+        'home.xyz' | 'xyz' | 'home'
+        'home.xyz' | '.xyz' | 'home'
+    }
+}


### PR DESCRIPTION
`ViewUtils.normalizeFile()` javadoc says 

> supports extensions that do and do not begin with a "."

This change fixes it so it actually does.