### PR TITLE
graalvm: remove build time initiazation

### DIFF
--- a/views-freemarker/src/main/resources/META-INF/native-image/io.micronaut.views.freemarker/native-image.properties
+++ b/views-freemarker/src/main/resources/META-INF/native-image/io.micronaut.views.freemarker/native-image.properties
@@ -1,3 +1,0 @@
-Args = -H:IncludeResources=freemarker/version.properties \
-       --initialize-at-build-time=freemarker \
-       --initialize-at-run-time=freemarker.ext.jython.JythonWrapper,freemarker.ext.jython.JythonModel

--- a/views-freemarker/src/main/resources/META-INF/native-image/io.micronaut.views.freemarker/resource-config.json
+++ b/views-freemarker/src/main/resources/META-INF/native-image/io.micronaut.views.freemarker/resource-config.json
@@ -1,0 +1,11 @@
+{
+  "resources":{
+  "includes":[
+    {
+      "pattern":"\\Qfreemarker/ext/beans/DefaultMemberAccessPolicy-rules\\E"
+    }, 
+    {
+      "pattern":"\\Qfreemarker/version.properties\\E"
+    }
+  ]}
+}

--- a/views-handlebars/src/main/resources/META-INF/native-image/io.micronaut.views.handlebars/native-image.properties
+++ b/views-handlebars/src/main/resources/META-INF/native-image/io.micronaut.views.handlebars/native-image.properties
@@ -1,1 +1,0 @@
-Args = --initialize-at-build-time=com.github.jknack.handlebars

--- a/views-handlebars/src/main/resources/META-INF/native-image/io.micronaut.views.handlebars/resource-config.json
+++ b/views-handlebars/src/main/resources/META-INF/native-image/io.micronaut.views.handlebars/resource-config.json
@@ -1,0 +1,10 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qhelpers.nashorn.js\\E"
+      }
+    ]
+  },
+  "bundles": []
+}

--- a/views-pebble/src/main/resources/META-INF/native-image/io.micronaut.views.pebble/native-image.properties
+++ b/views-pebble/src/main/resources/META-INF/native-image/io.micronaut.views.pebble/native-image.properties
@@ -1,1 +1,0 @@
-Args = --initialize-at-build-time=com.mitchellbosecke.pebble

--- a/views-thymeleaf/src/main/resources/META-INF/native-image/io.micronaut.views.thymeleaf/native-image.properties
+++ b/views-thymeleaf/src/main/resources/META-INF/native-image/io.micronaut.views.thymeleaf/native-image.properties
@@ -1,1 +1,0 @@
-Args = --initialize-at-build-time=javassist.ClassPool


### PR DESCRIPTION
Build time initialization is not really recommended. This PR removed it because it also not necessary anymore.