### PR TITLE
bug: ViewModelProcessor does not handle immutable maps

### DIFF
--- a/test-suite/src/test/java/io/micronaut/views/model/UnmodifiableFruitsController.java
+++ b/test-suite/src/test/java/io/micronaut/views/model/UnmodifiableFruitsController.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.views.model;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
+import io.micronaut.views.View;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Secured(SecurityRule.IS_AUTHENTICATED)
+@Requires(property = "spec.name", value = "UnmodifiableModelAndViewSpec")
+@Controller
+public class UnmodifiableFruitsController {
+
+    @View("unmodifiablefruits")
+    @Get("/unmodifiable")
+    public Map<String, Object> unmodifiableModel() {
+        return Collections.singletonMap("fruit", new Fruit("plum", "plum"));
+    }
+
+    @View("unmodifiablefruits")
+    @Get("/modifiable")
+    public Map<String, Object> modifiableModel() {
+        return CollectionUtils.mapOf("fruit", new Fruit("plum", "plum"));
+    }
+
+    @Introspected
+    public static class Fruit {
+        private final String name;
+        private final String color;
+
+        public Fruit(String name, String color) {
+            this.name = name;
+            this.color = color;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getColor() {
+            return color;
+        }
+    }
+}

--- a/test-suite/src/test/java/views/UnmodifiableModelAndViewTest.java
+++ b/test-suite/src/test/java/views/UnmodifiableModelAndViewTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package views;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.views.ModelAndView;
+import io.micronaut.views.View;
+import io.micronaut.views.model.ConfigViewModelProcessor;
+import io.micronaut.views.model.FruitsController;
+import io.micronaut.views.model.UnmodifiableFruitsController;
+import io.micronaut.views.model.ViewModelProcessor;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// Issue: https://github.com/micronaut-projects/micronaut-views/issues/336
+class UnmodifiableModelAndViewTest {
+
+    @Test
+    void anUnmodifiableViewModelReportsErrorButDoesNotCrash() {
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer.class, CollectionUtils.mapOf(
+                "spec.name", "UnmodifiableModelAndViewSpec",
+                "micronaut.views.soy.enabled", StringUtils.FALSE));
+        HttpClient httpClient = HttpClient.create(embeddedServer.getURL());
+
+        //given:
+        BlockingHttpClient client = httpClient.toBlocking();
+        //expect:
+        assertTrue(embeddedServer.getApplicationContext().containsBean(UnmodifiableFruitsController.class));
+
+        //when:
+        HttpRequest<?> request = HttpRequest.GET("/unmodifiable").basicAuth("john", "secret");
+        HttpResponse<String> response = client.exchange(request, String.class);
+
+        //then:
+        assertEquals(HttpStatus.OK, response.status());
+
+        //when:
+        String html = response.body();
+
+        //then:
+        assertNotNull(html);
+
+        //and:
+        assertFalse(html.contains("<blink>Security was added</blink>"));
+
+        //and:
+        assertTrue(html.contains("<h1>fruit: plum</h1>"));
+
+        //and:
+        assertTrue(html.contains("<h1>color: plum</h1>"));
+
+        //cleanup:
+        httpClient.close();
+
+        //and:
+        embeddedServer.close();
+    }
+
+    @Test
+    void aModifiableViewModelStillAddsSecurity() {
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer.class, CollectionUtils.mapOf(
+                "spec.name", "UnmodifiableModelAndViewSpec",
+                "micronaut.views.soy.enabled", StringUtils.FALSE));
+        HttpClient httpClient = HttpClient.create(embeddedServer.getURL());
+
+        //given:
+        BlockingHttpClient client = httpClient.toBlocking();
+        //expect:
+        assertTrue(embeddedServer.getApplicationContext().containsBean(UnmodifiableFruitsController.class));
+
+        //when:
+        HttpRequest<?> request = HttpRequest.GET("/modifiable").basicAuth("john", "secret");
+        HttpResponse<String> response = client.exchange(request, String.class);
+
+        //then:
+        assertEquals(HttpStatus.OK, response.status());
+
+        //when:
+        String html = response.body();
+
+        //then:
+        assertNotNull(html);
+
+        //and:
+        assertTrue(html.contains("<blink>Security was added</blink>"));
+
+        //and:
+        assertTrue(html.contains("<h1>fruit: plum</h1>"));
+
+        //and:
+        assertTrue(html.contains("<h1>color: plum</h1>"));
+
+        //cleanup:
+        httpClient.close();
+
+        //and:
+        embeddedServer.close();
+    }
+}

--- a/test-suite/src/test/java/views/UnmodifiableModelAndViewTest.java
+++ b/test-suite/src/test/java/views/UnmodifiableModelAndViewTest.java
@@ -81,7 +81,7 @@ class UnmodifiableModelAndViewTest {
         assertNotNull(html);
 
         //and:
-        assertFalse(html.contains("<blink>Security was added</blink>"));
+        assertTrue(html.contains("<blink>Security was added</blink>"));
 
         //and:
         assertTrue(html.contains("<h1>fruit: plum</h1>"));

--- a/test-suite/src/test/resources/views/unmodifiablefruits.vm
+++ b/test-suite/src/test/resources/views/unmodifiablefruits.vm
@@ -1,0 +1,20 @@
+#* @vtlvariable name="fruit" type="io.micronaut.views.model.FruitsController.Fruit" *#
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Fruits</title>
+</head>
+<body>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Fruits</title>
+</head>
+<body>
+#if( $security )
+    <blink>Security was added</blink>
+#end
+<h1>fruit: $fruit.getName()</h1>
+<h1>color: $fruit.getColor()</h1>
+</body>
+</html>

--- a/views-core/src/main/java/io/micronaut/views/model/security/SecurityViewModelProcessor.java
+++ b/views-core/src/main/java/io/micronaut/views/model/security/SecurityViewModelProcessor.java
@@ -25,6 +25,9 @@ import io.micronaut.views.ModelAndView;
 import io.micronaut.views.model.ViewModelProcessor;
 import io.micronaut.core.annotation.NonNull;
 import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -39,6 +42,8 @@ import java.util.Optional;
 @Requires(beans = {SecurityFilter.class, SecurityService.class, SecurityViewModelProcessorConfiguration.class})
 @Singleton
 public class SecurityViewModelProcessor implements ViewModelProcessor<Map<String, Object>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SecurityViewModelProcessor.class);
 
     private final SecurityService securityService;
     private final SecurityViewModelProcessorConfiguration securityViewModelProcessorConfiguration;
@@ -67,7 +72,11 @@ public class SecurityViewModelProcessor implements ViewModelProcessor<Map<String
                 modelAndView.setModel(newModel);
                 return newModel;
             });
-            viewModel.putIfAbsent(securityViewModelProcessorConfiguration.getSecurityKey(), securityModel);
+            try {
+                viewModel.putIfAbsent(securityViewModelProcessorConfiguration.getSecurityKey(), securityModel);
+            } catch (UnsupportedOperationException ex) {
+                LOG.error("Could not decorate unmodifiable view model with the security model (path '{}')", request.getPath(), ex);
+            }
         }
     }
 }

--- a/views-core/src/main/java/io/micronaut/views/model/security/SecurityViewModelProcessor.java
+++ b/views-core/src/main/java/io/micronaut/views/model/security/SecurityViewModelProcessor.java
@@ -75,7 +75,9 @@ public class SecurityViewModelProcessor implements ViewModelProcessor<Map<String
             try {
                 viewModel.putIfAbsent(securityViewModelProcessorConfiguration.getSecurityKey(), securityModel);
             } catch (UnsupportedOperationException ex) {
-                LOG.error("Could not decorate unmodifiable view model with the security model (path '{}')", request.getPath(), ex);
+                final HashMap<String, Object> modifiableModel = new HashMap<>(viewModel);
+                modifiableModel.putIfAbsent(securityViewModelProcessorConfiguration.getSecurityKey(), securityModel);
+                modelAndView.setModel(modifiableModel);
             }
         }
     }


### PR DESCRIPTION
The SecurityViewModelProcessor will fail the request and throw an UnsupportedOperationException
if an unmodifiable Map is used as the view model for a request.

This change catches that error, and logs an error explaining the issue, and showing the user
the path that caused the error to occur.

Fixes #336
