### PR TITLE
fix: protects against object not being of type String

### DIFF
--- a/views-thymeleaf/src/main/java/io/micronaut/views/thymeleaf/MessageSourceMessageResolver.java
+++ b/views-thymeleaf/src/main/java/io/micronaut/views/thymeleaf/MessageSourceMessageResolver.java
@@ -86,8 +86,11 @@ public class MessageSourceMessageResolver extends AbstractMessageResolver {
             int i;
             Map<String, Object> messageMap = new HashMap<>();
             for (i = 0; i < messageParameters.length; i++) {
-                String value = (String) messageParameters[i];
-                messageMap.put(String.valueOf(i), value);
+                Object val = messageParameters[i];
+                if (val != null) {
+                    String value = val.toString();
+                    messageMap.put(String.valueOf(i), value);
+                }
             }
             return messageMap;
         } else {

--- a/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/MicronautThymeMessageResolverSpec.groovy
+++ b/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/MicronautThymeMessageResolverSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.views.thymeleaf
 import io.micronaut.context.ApplicationContext
 import org.thymeleaf.TemplateEngine
 import org.thymeleaf.context.Context
+import org.thymeleaf.context.IContext
 import spock.lang.Specification
 
 class MicronautThymeMessageResolverSpec extends Specification {
@@ -75,6 +76,22 @@ class MicronautThymeMessageResolverSpec extends Specification {
 
         then:
         content.contains("nothing_en_US")
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "test message resolver translates non-string parameters"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+        TemplateEngine templateEngine = ctx.getBean(TemplateEngine)
+        IContext ictx = new Context(null, ['int1': 123, 'int2': 456])
+
+        when:
+        String content = templateEngine.process("thymeleaf/sample_int_params", ictx)
+
+        then:
+        content.contains("This is a message with first substitution 123 and then second substitution 456.")
 
         cleanup:
         ctx.close()

--- a/views-thymeleaf/src/test/resources/views/thymeleaf/sample_int_params.html
+++ b/views-thymeleaf/src/test/resources/views/thymeleaf/sample_int_params.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+    <head>
+        <title>Template Page</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    </head>
+    <body>
+        <h1><span th:text="#{sample.title}"></span></h1>
+        <p><span th:text="#{sample.body}"></span> </p>
+
+        <!--/*@thymesVar id="int1" type="java.lang.Integer"*/-->
+        <!--/*@thymesVar id="int2" type="java.lang.Integer"*/-->
+        <span th:text="#{sample.template(${int1}, ${int2})}"></span> </p>
+    </body>
+</html>


### PR DESCRIPTION
I got this crash when using thymeleaf and internationalization messages with an integer: 

```
subscriber.calltoaction.count=Join {0} subscribers!
```

```
aused by: java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.String (java.lang.Integer and java.lang.String are in module java.base of loader 'bootstrap')

	at io.micronaut.views.thymeleaf.MessageSourceMessageResolver.resolveMessage(MessageSourceMessageResolver.java:62)
	at org.thymeleaf.context.AbstractEngineContext.getMessage(AbstractEngineContext.java:134)
	at org.thymeleaf.standard.expression.MessageExpression.executeMessageExpression(MessageExpression.java:265)
	at org.thymeleaf.standard.expression.SimpleExpression.executeSimple(SimpleExpression.java:69)
	at org.thymeleaf.standard.expression.Expression.execute(Expression.java:109)
```