### PR TITLE
refactor: make HttpRequest parameter in ViewsRenderer nullable

### DIFF
--- a/test-suite/src/test/java/views/NonHTMLViewRendererTest.java
+++ b/test-suite/src/test/java/views/NonHTMLViewRendererTest.java
@@ -95,7 +95,8 @@ class NonHTMLViewRendererTest {
     @Singleton
     static class XmlViewRenderer implements ViewsRenderer<Library> {
         @Override
-        public Writable render(@NonNull String viewName, @Nullable Library data, @NonNull HttpRequest<?> request) {
+        @NonNull
+        public Writable render(@NonNull String viewName, @Nullable Library data, @Nullable HttpRequest<?> request) {
             return new Writable() {
                 @Override
                 public void writeTo(Writer out) throws IOException {
@@ -119,7 +120,10 @@ class NonHTMLViewRendererTest {
         // this renderer should not be used because it specifies a different type
 
         @Override
-        public Writable render(@NonNull String viewName, @Nullable Book data, @NonNull HttpRequest<?> request) {
+        @NonNull
+        public Writable render(@NonNull String viewName,
+                               @Nullable Book data,
+                               @Nullable HttpRequest<?> request) {
             return new Writable() {
                 @Override
                 public void writeTo(Writer out) throws IOException {
@@ -144,7 +148,10 @@ class NonHTMLViewRendererTest {
     @Singleton
     public static class CsvViewRenderer implements ViewsRenderer<Library> {
         @Override
-        public Writable render(@NonNull String viewName, @Nullable Library data, @NonNull HttpRequest<?> request) {
+        @NonNull
+        public Writable render(@NonNull String viewName,
+                               @Nullable Library data,
+                               @Nullable HttpRequest<?> request) {
             return new Writable() {
                 @Override
                 public void writeTo(Writer out) throws IOException {

--- a/views-core/src/main/java/io/micronaut/views/ViewsRenderer.java
+++ b/views-core/src/main/java/io/micronaut/views/ViewsRenderer.java
@@ -35,7 +35,9 @@ public interface ViewsRenderer<T> extends Ordered {
      * @param request  HTTP request
      * @return A writable where the view will be written to.
      */
-    @NonNull Writable render(@NonNull String viewName, @Nullable T data, @NonNull HttpRequest<?> request);
+    @NonNull Writable render(@NonNull String viewName,
+                             @Nullable T data,
+                             @Nullable HttpRequest<?> request);
 
     /**
      * @param viewName view name to be rendered

--- a/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
+++ b/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
@@ -67,7 +67,9 @@ public class FreemarkerViewsRenderer<T> implements ViewsRenderer<T> {
 
     @NonNull
     @Override
-    public Writable render(@NonNull String viewName, @Nullable T data, @NonNull HttpRequest<?> request) {
+    public Writable render(@NonNull String viewName,
+                           @Nullable T data,
+                           @Nullable HttpRequest<?> request) {
         ArgumentUtils.requireNonNull("viewName", viewName);
         return (writer) -> {
             Map<String, Object> context = ViewUtils.modelOf(data);

--- a/views-freemarker/src/test/groovy/io/micronaut/views/freemarker/FreemarkerViewRenderNullableRequestSpec.groovy
+++ b/views-freemarker/src/test/groovy/io/micronaut/views/freemarker/FreemarkerViewRenderNullableRequestSpec.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.views.freemarker
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+import io.micronaut.core.io.Writable
+
+@MicronautTest(startApplication = false)
+class FreemarkerViewRenderNullableRequestSpec extends Specification {
+
+    @Inject
+    FreemarkerViewsRenderer<?> viewRenderer
+
+    void "views can be render with no request"() {
+        when:
+        Writable writeable = viewRenderer.render("tim", ["username": "Tim"], null)
+        String result = new StringWriter().with {
+            writeable.writeTo(it)
+            it.toString()
+        }
+
+        then:
+        result.contains("username: <span>Tim</span>")
+    }
+}

--- a/views-freemarker/src/test/resources/views/tim.ftl
+++ b/views-freemarker/src/test/resources/views/tim.ftl
@@ -1,0 +1,1 @@
+username: <span>${username}</span>

--- a/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRenderer.java
+++ b/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRenderer.java
@@ -72,7 +72,9 @@ public class HandlebarsViewsRenderer<T> implements ViewsRenderer<T> {
 
     @NonNull
     @Override
-    public Writable render(@NonNull String viewName, @Nullable T data, @NonNull HttpRequest<?> request) {
+    public Writable render(@NonNull String viewName,
+                           @Nullable T data,
+                           @Nullable HttpRequest<?> request) {
         ArgumentUtils.requireNonNull("viewName", viewName);
         return (writer) -> {
             String location = viewLocation(viewName);

--- a/views-handlebars/src/test/groovy/io/micronaut/views/handlebars/HandlebarsViewRenderNullableRequestSpec.groovy
+++ b/views-handlebars/src/test/groovy/io/micronaut/views/handlebars/HandlebarsViewRenderNullableRequestSpec.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.views.handlebars
+
+import io.micronaut.core.io.Writable
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class HandlebarsViewRenderNullableRequestSpec extends Specification {
+
+    @Inject
+    HandlebarsViewsRenderer<?> viewRenderer
+
+    void "views can be render with no request"() {
+        when:
+        Writable writeable = viewRenderer.render("tim", ["username": "Tim"], null)
+        String result = new StringWriter().with {
+            writeable.writeTo(it)
+            it.toString()
+        }
+
+        then:
+        result.contains("username: <span>Tim</span>")
+    }
+}

--- a/views-handlebars/src/test/resources/views/tim.hbs
+++ b/views-handlebars/src/test/resources/views/tim.hbs
@@ -1,0 +1,1 @@
+username: <span>{{username}}</span>

--- a/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRenderer.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRenderer.java
@@ -21,6 +21,7 @@ import gg.jte.TemplateOutput;
 import gg.jte.output.WriterOutput;
 import gg.jte.resolve.ResourceCodeResolver;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.io.Writable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.views.ViewUtils;
@@ -61,7 +62,9 @@ public abstract class JteViewsRenderer<T> implements ViewsRenderer<T> {
 
     @NonNull
     @Override
-    public Writable render(@NonNull String viewName, T data, @NonNull HttpRequest<?> request) {
+    public Writable render(@NonNull String viewName,
+                           @Nullable T data,
+                           @Nullable HttpRequest<?> request) {
         return out -> {
             TemplateOutput output = getOutput(out);
             Map<String, Object> dataMap = ViewUtils.modelOf(data);

--- a/views-jte/src/test/groovy/io/micronaut/jte/JteViewRenderNullableRequestSpec.groovy
+++ b/views-jte/src/test/groovy/io/micronaut/jte/JteViewRenderNullableRequestSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.jte
+
+import io.micronaut.core.io.Writable
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.views.ViewsRenderer
+import io.micronaut.views.jte.JteViewsRenderer
+import io.micronaut.views.jte.PlainJteViewsRenderer
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class JteViewRenderNullableRequestSpec extends Specification {
+
+    @Inject
+    PlainJteViewsRenderer<?> plainJteViewsRenderer
+
+    @Inject
+    PlainJteViewsRenderer<?> htmlJteViewsRenderer
+
+    void "views can be render with no request"() {
+        expect:
+        output(plainJteViewsRenderer).contains("username: <span>Tim</span>")
+        output(htmlJteViewsRenderer).contains("username: <span>Tim</span>")
+    }
+
+    private static String output(ViewsRenderer<?> viewsRenderer) {
+        Writable writeable = viewsRenderer.render("tim", ["username": "Tim"], null)
+        new StringWriter().with {
+            writeable.writeTo(it)
+            it.toString()
+        }
+    }
+}

--- a/views-jte/src/test/resources/views/tim.jte
+++ b/views-jte/src/test/resources/views/tim.jte
@@ -1,0 +1,2 @@
+@param String username
+username: <span>${username}</span>

--- a/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleViewsRenderer.java
+++ b/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleViewsRenderer.java
@@ -18,6 +18,7 @@ package io.micronaut.views.pebble;
 import com.mitchellbosecke.pebble.PebbleEngine;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.io.Writable;
 import io.micronaut.core.util.LocaleResolver;
 import io.micronaut.core.util.StringUtils;
@@ -88,12 +89,15 @@ public class PebbleViewsRenderer<T> implements ViewsRenderer<T> {
     }
 
     @Override
-    public Writable render(String name, T data, @NonNull HttpRequest<?> request) {
-        return (writer) -> engine.getTemplate(name).evaluate(writer, ViewUtils.modelOf(data), httpLocaleResolver.resolveOrDefault(request));
+    @NonNull
+    public Writable render(@NonNull String name,
+                           @Nullable T data,
+                           @Nullable HttpRequest<?> request) {
+        return (writer) -> engine.getTemplate(name).evaluate(writer, ViewUtils.modelOf(data), request != null ? httpLocaleResolver.resolveOrDefault(request) : Locale.getDefault());
     }
 
     @Override
-    public boolean exists(String name) {
+    public boolean exists(@NonNull String name) {
         return engine.getLoader().resourceExists(name);
     }
 }

--- a/views-pebble/src/test/groovy/io/micronaut/views/pebble/PebbleViewRenderNullableRequestSpec.groovy
+++ b/views-pebble/src/test/groovy/io/micronaut/views/pebble/PebbleViewRenderNullableRequestSpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.views.pebble
+
+import io.micronaut.core.io.Writable
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.views.ViewsRenderer
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class PebbleViewRenderNullableRequestSpec extends Specification {
+
+    @Inject
+    PebbleViewsRenderer<?> viewRenderer
+
+    void "views can be render with no request"() {
+        when:
+        Writable writeable = viewRenderer.render("tim", ["username": "Tim"], null)
+        String result = new StringWriter().with {
+            writeable.writeTo(it)
+            it.toString()
+        }
+
+        then:
+        result.contains("username: <span>Tim</span>")
+    }
+}

--- a/views-pebble/src/test/resources/views/tim.html
+++ b/views-pebble/src/test/resources/views/tim.html
@@ -1,0 +1,1 @@
+username: <span>{{ username }}</span>

--- a/views-rocker/src/main/java/io/micronaut/views/rocker/RockerViewsRenderer.java
+++ b/views-rocker/src/main/java/io/micronaut/views/rocker/RockerViewsRenderer.java
@@ -60,7 +60,9 @@ public class RockerViewsRenderer<T> implements ViewsRenderer<T> {
 
     @NonNull
     @Override
-    public Writable render(@NonNull String view, @Nullable T data, @NonNull HttpRequest<?> request) {
+    public Writable render(@NonNull String view,
+                           @Nullable T data,
+                           @Nullable HttpRequest<?> request) {
         ArgumentUtils.requireNonNull("view", view);
 
         Map<String, Object> context = ViewUtils.modelOf(data);

--- a/views-rocker/src/test/groovy/io/micronaut/views/rocker/RockerViewRenderNullableRequestSpec.groovy
+++ b/views-rocker/src/test/groovy/io/micronaut/views/rocker/RockerViewRenderNullableRequestSpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.views.rocker
+
+import io.micronaut.core.io.Writable
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.views.ViewsRenderer
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class RockerViewRenderNullableRequestSpec extends Specification {
+
+    @Inject
+    RockerViewsRenderer<?> viewRenderer
+
+    void "views can be render with no request"() {
+        when:
+        Writable writeable = viewRenderer.render("tim", ["username": "Tim"], null)
+        String result = new StringWriter().with {
+            writeable.writeTo(it)
+            it.toString()
+        }
+
+        then:
+        result.contains("username: <span>Tim</span>")
+    }
+}

--- a/views-rocker/src/test/resources/views/tim.rocker.html
+++ b/views-rocker/src/test/resources/views/tim.rocker.html
@@ -1,0 +1,2 @@
+@args (String username)
+username: <span>@username</span>

--- a/views-soy/src/main/java/io/micronaut/views/soy/SoySauceViewsRenderer.java
+++ b/views-soy/src/main/java/io/micronaut/views/soy/SoySauceViewsRenderer.java
@@ -104,7 +104,9 @@ public class SoySauceViewsRenderer<T> implements ViewsRenderer<T> {
      */
     @NonNull
     @Override
-    public Writable render(@NonNull String viewName, @Nullable T data, @NonNull HttpRequest<?> request) {
+    public Writable render(@NonNull String viewName,
+                           @Nullable T data,
+                           @Nullable HttpRequest<?> request) {
         ArgumentUtils.requireNonNull("viewName", viewName);
 
         Map<String, Object> ijOverlay = new HashMap<>(1);
@@ -122,7 +124,7 @@ public class SoySauceViewsRenderer<T> implements ViewsRenderer<T> {
         });
         renderer.setData(context);
         if (injectNonce) {
-            Optional<Object> nonceObj = request.getAttribute(CspFilter.NONCE_PROPERTY);
+            Optional<Object> nonceObj = request != null ? request.getAttribute(CspFilter.NONCE_PROPERTY) : Optional.empty();
             if (nonceObj.isPresent()) {
                 String nonceValue = ((String) nonceObj.get());
                 ijOverlay.put(INJECTED_NONCE_PROPERTY, nonceValue);

--- a/views-soy/src/test/groovy/io/micronaut/views/soy/SoyViewRenderNullableRequestSpec.groovy
+++ b/views-soy/src/test/groovy/io/micronaut/views/soy/SoyViewRenderNullableRequestSpec.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.views.soy
+
+import io.micronaut.core.io.Writable
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class SoyViewRenderNullableRequestSpec extends Specification {
+
+    @Inject
+    SoySauceViewsRenderer<?> viewRenderer
+
+    void "views can be render with no request"() {
+        when:
+        Writable writeable = viewRenderer.render("sample.tim", ["username": "Tim"], null)
+        String result = new StringWriter().with {
+            writeable.writeTo(it)
+            it.toString()
+        }
+
+        then:
+        result.contains("username: <span>Tim</span>")
+    }
+}

--- a/views-soy/src/test/resources/views/home.soy
+++ b/views-soy/src/test/resources/views/home.soy
@@ -21,3 +21,7 @@
   </body>
   </html>
 {/template}
+{template .tim}
+  {@param? username: string}
+  username: <span>{$username}</span>
+{/template}

--- a/views-thymeleaf/src/main/java/io/micronaut/views/thymeleaf/ThymeleafViewsRenderer.java
+++ b/views-thymeleaf/src/main/java/io/micronaut/views/thymeleaf/ThymeleafViewsRenderer.java
@@ -101,11 +101,10 @@ public class ThymeleafViewsRenderer<T> implements ViewsRenderer<T> {
     @NonNull
     public Writable render(@NonNull String viewName,
                            @Nullable T data,
-                           @NonNull HttpRequest<?> request) {
+                           @Nullable HttpRequest<?> request) {
         ArgumentUtils.requireNonNull("viewName", viewName);
-        ArgumentUtils.requireNonNull("request", request);
         return (writer) -> {
-            IContext context = new WebContext(request, httpLocaleResolver.resolveOrDefault(request),
+            IContext context = new WebContext(request, request != null ? httpLocaleResolver.resolveOrDefault(request) : Locale.getDefault(),
                     ViewUtils.modelOf(data));
             render(viewName, context, writer);
         };

--- a/views-thymeleaf/src/main/java/io/micronaut/views/thymeleaf/WebContext.java
+++ b/views-thymeleaf/src/main/java/io/micronaut/views/thymeleaf/WebContext.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.views.thymeleaf;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import org.thymeleaf.context.AbstractContext;
 
@@ -30,13 +31,15 @@ import java.util.Map;
  */
 public class WebContext extends AbstractContext {
 
+    @Nullable
     private final HttpRequest<?> request;
 
     /**
      * @param request HTTP request.
      * @see AbstractContext#AbstractContext().
      */
-    public WebContext(HttpRequest<?> request) {
+    @Deprecated
+    public WebContext(@Nullable HttpRequest<?> request) {
         this.request = request;
     }
 
@@ -45,7 +48,8 @@ public class WebContext extends AbstractContext {
      * @param request HTTP request.
      * @see AbstractContext#AbstractContext(Locale).
      */
-    public WebContext(HttpRequest<?> request, Locale locale) {
+    @Deprecated
+    public WebContext(@Nullable HttpRequest<?> request, Locale locale) {
         super(locale);
         this.request = request;
     }
@@ -56,7 +60,7 @@ public class WebContext extends AbstractContext {
      * @param variables the variables.
      * @see AbstractContext#AbstractContext(Locale, Map).
      */
-    public WebContext(HttpRequest<?> request, Locale locale, Map<String, Object> variables) {
+    public WebContext(@Nullable HttpRequest<?> request, Locale locale, Map<String, Object> variables) {
         super(locale, variables);
         this.request = request;
     }
@@ -64,6 +68,7 @@ public class WebContext extends AbstractContext {
     /**
      * @return HTTP request.
      */
+    @Nullable
     public HttpRequest<?> getRequest() {
         return request;
     }

--- a/views-thymeleaf/src/main/java/io/micronaut/views/thymeleaf/WebEngineContext.java
+++ b/views-thymeleaf/src/main/java/io/micronaut/views/thymeleaf/WebEngineContext.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.views.thymeleaf;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import org.thymeleaf.IEngineConfiguration;
 import org.thymeleaf.context.EngineContext;
@@ -31,6 +32,7 @@ import java.util.Map;
  */
 public class WebEngineContext extends EngineContext {
 
+    @Nullable
     private final HttpRequest<?> request;
 
     /**
@@ -45,7 +47,9 @@ public class WebEngineContext extends EngineContext {
      */
     public WebEngineContext(
             IEngineConfiguration configuration, TemplateData templateData,
-            Map<String, Object> templateResolutionAttributes, HttpRequest<?> request, Locale locale,
+            Map<String, Object> templateResolutionAttributes,
+            @Nullable HttpRequest<?> request,
+            Locale locale,
             Map<String, Object> variables) {
         super(configuration, templateData, templateResolutionAttributes, locale, variables);
         this.request = request;
@@ -54,6 +58,7 @@ public class WebEngineContext extends EngineContext {
     /**
      * @return HTTP request.
      */
+    @Nullable
     public HttpRequest<?> getRequest() {
         return request;
     }

--- a/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderNullableRequestSpec.groovy
+++ b/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderNullableRequestSpec.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.views.thymeleaf
+
+import io.micronaut.core.io.Writable
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class ThymeleafViewRenderNullableRequestSpec extends Specification {
+
+    @Inject
+    ThymeleafViewsRenderer<?> viewRenderer
+
+    void "views can be render with no request"() {
+        when:
+        Writable writeable = viewRenderer.render("tim", ["username": "Tim"], null)
+        String result = new StringWriter().with {
+            writeable.writeTo(it)
+            it.toString()
+        }
+
+        then:
+        result.contains("username: <span>Tim</span>")
+    }
+}

--- a/views-thymeleaf/src/test/resources/views/tim.html
+++ b/views-thymeleaf/src/test/resources/views/tim.html
@@ -1,0 +1,1 @@
+username: <span th:text="${username}"></span>

--- a/views-velocity/src/test/groovy/io/micronaut/views/velocity/VelocityViewRenderNullableRequestSpec.groovy
+++ b/views-velocity/src/test/groovy/io/micronaut/views/velocity/VelocityViewRenderNullableRequestSpec.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.views.velocity
+
+import io.micronaut.core.io.Writable
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class VelocityViewRenderNullableRequestSpec extends Specification {
+
+    @Inject
+    VelocityViewsRenderer<?> viewRenderer
+
+    void "views can be render with no request"() {
+        when:
+        Writable writeable = viewRenderer.render("tim", ["username": "Tim"], null)
+        String result = new StringWriter().with {
+            writeable.writeTo(it)
+            it.toString()
+        }
+
+        then:
+        result.contains("username: <span>Tim</span>")
+    }
+}

--- a/views-velocity/src/test/resources/views/tim.vm
+++ b/views-velocity/src/test/resources/views/tim.vm
@@ -1,0 +1,1 @@
+username: <span>$username</span>


### PR DESCRIPTION
This makes the `ViewsRenderer` HTTP Request parameter nullable. It is used for example, in the Micronaut Email module and you may use it in places where you don't have an HTTP Request (For example, in a cron job). 