### PR TITLE
support binary static content in JTE

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ velocityVersion=2.3
 rockerVersion=1.3.0
 soyVersion=2022-03-02
 pebbleVersion=3.1.5
-jteVersion=2.0.2
+jteVersion=2.0.3
 
 title=Micronaut Views
 projectDesc=Provides integration between Micronaut and server-side views technologies

--- a/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRenderer.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRenderer.java
@@ -15,16 +15,21 @@
  */
 package io.micronaut.views.jte;
 
-import gg.jte.*;
-import gg.jte.output.*;
-import gg.jte.resolve.*;
-import io.micronaut.core.annotation.*;
-import io.micronaut.core.io.*;
-import io.micronaut.http.*;
-import io.micronaut.views.*;
+import gg.jte.ContentType;
+import gg.jte.TemplateEngine;
+import gg.jte.TemplateOutput;
+import gg.jte.output.WriterOutput;
+import gg.jte.resolve.ResourceCodeResolver;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.io.Writable;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.views.ViewUtils;
+import io.micronaut.views.ViewsConfiguration;
+import io.micronaut.views.ViewsRenderer;
 
-import java.io.*;
-import java.nio.file.*;
+import java.io.Writer;
+import java.nio.file.Path;
 
 /**
  * View renderer using JTE.

--- a/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRendererConfiguration.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRendererConfiguration.java
@@ -33,4 +33,11 @@ public interface JteViewsRendererConfiguration {
      * @return the directory
      */
     String getDynamicPath();
+
+    /**
+     * When using dynamic templates, build them with binary content (see https://github.com/casid/jte/blob/master/DOCUMENTATION.md#binary-rendering-for-max-throughput).
+     * (When using precompiled templates, this setting is determined by the build configuration.)
+     * @return true to enable building binary content
+     */
+    boolean isBinaryStaticContent();
 }

--- a/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRendererConfigurationProperties.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRendererConfigurationProperties.java
@@ -41,8 +41,11 @@ public final class JteViewsRendererConfigurationProperties implements JteViewsRe
     @SuppressWarnings("WeakerAccess")
     public static final String DEFAULT_DYNAMIC_PATH = "build/jte-classes";
 
+    public static final boolean DEFAULT_BINARY_STATIC_CONTENT = false;
+
     private boolean dynamic = DEFAULT_DYNAMIC;
     private String dynamicPath = DEFAULT_DYNAMIC_PATH;
+    private boolean binaryStaticContent = DEFAULT_BINARY_STATIC_CONTENT;
 
     /**
      * Whether to enable dynamic reloading of templates. Default value ({@value #DEFAULT_DYNAMIC}).
@@ -68,5 +71,19 @@ public final class JteViewsRendererConfigurationProperties implements JteViewsRe
     @Override
     public String getDynamicPath() {
         return dynamicPath;
+    }
+
+    @Override
+    public boolean isBinaryStaticContent() {
+        return binaryStaticContent;
+    }
+
+    /**
+     * Enable building binary content for templates. Default value ({@value #DEFAULT_BINARY_STATIC_CONTENT}).
+     * (Only has an effect when 'dynamic' is true. To use with precompiled templates, enable it in the build plugin)
+     * @param binaryStaticContent true to enable binary content
+     */
+    public void setBinaryStaticContent(boolean binaryStaticContent) {
+        this.binaryStaticContent = binaryStaticContent;
     }
 }

--- a/views-jte/src/main/java/io/micronaut/views/jte/JteWritable.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/JteWritable.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.views.jte;
+
+import gg.jte.*;
+import gg.jte.output.*;
+import io.micronaut.core.io.*;
+
+import java.io.*;
+import java.nio.charset.*;
+import java.util.*;
+import java.util.function.*;
+
+/**
+ * Turn JTE rendering logic into a Writable
+ */
+public class JteWritable implements Writable {
+    private final TemplateEngine templateEngine;
+    private final String viewName;
+    private final Map<String, Object> data;
+    private final Function<TemplateOutput, TemplateOutput> outputDecorator;
+
+    public JteWritable(TemplateEngine templateEngine, String viewName, Map<String, Object> data, Function<TemplateOutput, TemplateOutput> outputDecorator) {
+        this.templateEngine = templateEngine;
+        this.viewName = viewName;
+        this.data = data;
+        this.outputDecorator = outputDecorator;
+    }
+
+    private void render(TemplateOutput output) {
+        TemplateOutput decorated = outputDecorator.apply(output);
+        templateEngine.render(viewName, data, decorated);
+    }
+
+    @Override
+    public void writeTo(Writer out) throws IOException {
+        TemplateOutput output = new WriterOutput(out);
+        render(output);
+    }
+
+    @Override
+    public void writeTo(OutputStream outputStream, Charset charset) throws IOException {
+        if (charset == null || StandardCharsets.UTF_8.equals(charset)) {
+            // this enables "binary output" - see https://github.com/casid/jte/blob/master/DOCUMENTATION.md#binary-rendering-for-max-throughput
+            Utf8ByteOutput output = new Utf8ByteOutput();
+            render(output);
+            output.writeTo(outputStream);
+        } else {
+            Writable.super.writeTo(outputStream, charset);
+        }
+    }
+}

--- a/views-jte/src/main/java/io/micronaut/views/jte/JteWritable.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/JteWritable.java
@@ -15,14 +15,19 @@
  */
 package io.micronaut.views.jte;
 
-import gg.jte.*;
-import gg.jte.output.*;
-import io.micronaut.core.io.*;
+import gg.jte.TemplateEngine;
+import gg.jte.TemplateOutput;
+import gg.jte.output.Utf8ByteOutput;
+import gg.jte.output.WriterOutput;
+import io.micronaut.core.io.Writable;
 
-import java.io.*;
-import java.nio.charset.*;
-import java.util.*;
-import java.util.function.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Turn JTE rendering logic into a Writable

--- a/views-jte/src/main/java/io/micronaut/views/jte/PlainJteViewsRenderer.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/PlainJteViewsRenderer.java
@@ -15,8 +15,7 @@
  */
 package io.micronaut.views.jte;
 
-import gg.jte.ContentType;
-import gg.jte.TemplateOutput;
+import gg.jte.*;
 import gg.jte.html.HtmlTemplateOutput;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.MediaType;
@@ -47,12 +46,8 @@ public class PlainJteViewsRenderer<T> extends JteViewsRenderer<T> {
 
     @Override
     @NonNull
-    protected TemplateOutput getOutput(Writer out) {
-        TemplateOutput result = super.getOutput(out);
-        if (!(result instanceof HtmlTemplateOutput)) {
-            result = new PlainHtmlTemplateOutput(result);
-        }
-        return result;
+    TemplateOutput decorateOutput(@NonNull TemplateOutput output) {
+        return new PlainHtmlTemplateOutput(output);
     }
 
     /**
@@ -78,6 +73,81 @@ public class PlainJteViewsRenderer<T> extends JteViewsRenderer<T> {
         @Override
         public void setContext(String tagName, String attributeName) {
             // no-op
+        }
+
+        @Override
+        public void writeBinaryContent(byte[] value) {
+            delegate.writeBinaryContent(value);
+        }
+
+        @Override
+        public void writeUserContent(String value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(Enum<?> value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(Content content) {
+            delegate.writeUserContent(content);
+        }
+
+        @Override
+        public void writeUserContent(boolean value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(byte value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(short value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(int value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(long value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(float value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(double value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(char value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(Boolean value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(Number value) {
+            delegate.writeUserContent(value);
+        }
+
+        @Override
+        public void writeUserContent(Character value) {
+            delegate.writeUserContent(value);
         }
     }
 }

--- a/views-jte/src/main/java/io/micronaut/views/jte/PlainJteViewsRenderer.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/PlainJteViewsRenderer.java
@@ -15,7 +15,9 @@
  */
 package io.micronaut.views.jte;
 
-import gg.jte.*;
+import gg.jte.Content;
+import gg.jte.ContentType;
+import gg.jte.TemplateOutput;
 import gg.jte.html.HtmlTemplateOutput;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.MediaType;

--- a/views-jte/src/test/groovy/io/micronaut/docs/BinaryJteViewRendererSpec.groovy
+++ b/views-jte/src/test/groovy/io/micronaut/docs/BinaryJteViewRendererSpec.groovy
@@ -1,0 +1,13 @@
+package io.micronaut.docs
+
+class BinaryJteViewRendererSpec extends JteViewRendererSpec {
+    @Override
+    Map<String, Object> getTestProperties() {
+        return [
+                'spec.name': 'jte',
+                'micronaut.security.enabled': false,
+                'micronaut.views.jte.dynamic': true,
+                'micronaut.views.jte.binaryStaticContent': true
+        ] as Map<String, Object>
+    }
+}

--- a/views-jte/src/test/groovy/io/micronaut/docs/JteViewRendererSpec.groovy
+++ b/views-jte/src/test/groovy/io/micronaut/docs/JteViewRendererSpec.groovy
@@ -36,7 +36,8 @@ class JteViewRendererSpec extends Specification {
             [
                     'spec.name': 'jte',
                     'micronaut.security.enabled': false,
-                    'micronaut.views.jte.dynamic': true
+                    'micronaut.views.jte.dynamic': true,
+                    'micronaut.views.jte.binaryStaticContent': true
             ],
             "test")
 

--- a/views-jte/src/test/groovy/io/micronaut/docs/JteViewRendererSpec.groovy
+++ b/views-jte/src/test/groovy/io/micronaut/docs/JteViewRendererSpec.groovy
@@ -28,22 +28,19 @@ import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 
-class JteViewRendererSpec extends Specification {
+abstract class JteViewRendererSpec extends Specification {
 
     @Shared
     @AutoCleanup
     EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
-            [
-                    'spec.name': 'jte',
-                    'micronaut.security.enabled': false,
-                    'micronaut.views.jte.dynamic': true,
-                    'micronaut.views.jte.binaryStaticContent': true
-            ],
+            testProperties,
             "test")
 
     @Shared
     @AutoCleanup
     HttpClient client = embeddedServer.getApplicationContext().createBean(HttpClient, embeddedServer.getURL())
+
+    abstract Map<String, Object> getTestProperties()
 
     def "bean is loaded"() {
         when:

--- a/views-jte/src/test/groovy/io/micronaut/docs/WriterJteViewRendererSpec.groovy
+++ b/views-jte/src/test/groovy/io/micronaut/docs/WriterJteViewRendererSpec.groovy
@@ -1,0 +1,12 @@
+package io.micronaut.docs
+
+class WriterJteViewRendererSpec extends JteViewRendererSpec {
+    @Override
+    Map<String, Object> getTestProperties() {
+        return [
+                'spec.name': 'jte',
+                'micronaut.security.enabled': false,
+                'micronaut.views.jte.dynamic': true
+        ] as Map<String, Object>
+    }
+}


### PR DESCRIPTION
Update JTE to latest version.

Support for 'binary static content' in JTE. This pre-converts Strings to UTF-8 bytes to reduce work during rendering.