### PR TITLE
JTE - support dynamic template loading from src path

### DIFF
--- a/src/main/docs/guide/views/templates/jte.adoc
+++ b/src/main/docs/guide/views/templates/jte.adoc
@@ -17,6 +17,10 @@ include::{testsviewsJte}/resources/views/home.jte[]
 
 Jte templates may be precompiled at build time. This can be done by a https://github.com/casid/jte/blob/master/DOCUMENTATION.md#gradle[Gradle plugin] or https://github.com/casid/jte/blob/master/DOCUMENTATION.md#maven[Maven plugin]. If not precompiled, the application will need a JDK so it can compile templates at runtime.
 
+=== Dynamic Reloading
+
+When 'dynamic' is enabled (see below), JTE will load templates from the project source directory, and will reload them after changes.
+
 === Configuration
 
 The properties used can be customized by overriding the values of:

--- a/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRendererConfiguration.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRendererConfiguration.java
@@ -35,6 +35,13 @@ public interface JteViewsRendererConfiguration {
     String getDynamicPath();
 
     /**
+     * When using dynamic templates, the root source directory to search. If not specified, jte will
+     * search src/main/jte and src/main/resources/&lt;folder&gt; where folder is ViewsConfiguration.getFolder().
+     * @return the directory
+     */
+    String getDynamicSourcePath();
+
+    /**
      * When using dynamic templates, build them with binary content (see https://github.com/casid/jte/blob/master/DOCUMENTATION.md#binary-rendering-for-max-throughput).
      * (When using precompiled templates, this setting is determined by the build configuration.)
      * @return true to enable building binary content

--- a/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRendererConfigurationProperties.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRendererConfigurationProperties.java
@@ -79,6 +79,13 @@ public final class JteViewsRendererConfigurationProperties implements JteViewsRe
         return dynamicSourcePath;
     }
 
+    /**
+     * When using dynamic templates, the root source directory to search. If not specified, jte will
+     * search src/&lt;sourceset&gt;/jte and src/&lt;sourceset&gt;/resources/&lt;folder&gt; where
+     * 'folder' is ViewsConfiguration.getFolder(). In cases where the source directory cannot be found,
+     * jte will use classpath loading instead, and will not dynamically reload templates.
+     * @param path the directory
+     */
     public void setDynamicSourcePath(String path) {
         this.dynamicSourcePath = path;
     }

--- a/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRendererConfigurationProperties.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/JteViewsRendererConfigurationProperties.java
@@ -46,6 +46,7 @@ public final class JteViewsRendererConfigurationProperties implements JteViewsRe
     private boolean dynamic = DEFAULT_DYNAMIC;
     private String dynamicPath = DEFAULT_DYNAMIC_PATH;
     private boolean binaryStaticContent = DEFAULT_BINARY_STATIC_CONTENT;
+    private String dynamicSourcePath;
 
     /**
      * Whether to enable dynamic reloading of templates. Default value ({@value #DEFAULT_DYNAMIC}).
@@ -71,6 +72,15 @@ public final class JteViewsRendererConfigurationProperties implements JteViewsRe
     @Override
     public String getDynamicPath() {
         return dynamicPath;
+    }
+
+    @Override
+    public String getDynamicSourcePath() {
+        return dynamicSourcePath;
+    }
+
+    public void setDynamicSourcePath(String path) {
+        this.dynamicSourcePath = path;
     }
 
     @Override

--- a/views-jte/src/main/java/io/micronaut/views/jte/JteWritable.java
+++ b/views-jte/src/main/java/io/micronaut/views/jte/JteWritable.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Turn JTE rendering logic into a Writable
+ * Turn JTE rendering logic into a Writable.
  */
 public class JteWritable implements Writable {
     private final TemplateEngine templateEngine;

--- a/views-jte/src/test/groovy/io/micronaut/docs/DynamicRendererSpec.groovy
+++ b/views-jte/src/test/groovy/io/micronaut/docs/DynamicRendererSpec.groovy
@@ -1,0 +1,44 @@
+package io.micronaut.docs
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DynamicRendererSpec extends Specification {
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+            [
+                    'spec.name': 'jte',
+                    'micronaut.security.enabled': false,
+                    'micronaut.views.jte.dynamic': true,
+            'micronaut.views.jte.dynamicSourcePath': 'src/test/jte'],
+            "test")
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = embeddedServer.getApplicationContext().createBean(HttpClient, embeddedServer.getURL())
+
+    def 'invoking /jte/hello returns a page'() {
+
+        when:
+        HttpResponse<String> rsp = client.toBlocking().exchange('/jte/hello', String)
+
+        then:
+        noExceptionThrown()
+        rsp.status() == HttpStatus.OK
+
+        when:
+        String body = rsp.body()
+
+        then:
+        body
+        rsp.body().contains("world")
+    }
+
+}

--- a/views-jte/src/test/groovy/io/micronaut/docs/JteController.groovy
+++ b/views-jte/src/test/groovy/io/micronaut/docs/JteController.groovy
@@ -83,4 +83,10 @@ class JteController {
     HttpResponse nullBody() {
         HttpResponse.ok()
     }
+
+    @View("dynamic")
+    @Get("/hello")
+    HttpResponse hello() {
+        HttpResponse.ok([message: 'world'])
+    }
 }

--- a/views-jte/src/test/groovy/io/micronaut/jte/JteViewRenderNullableRequestSpec.groovy
+++ b/views-jte/src/test/groovy/io/micronaut/jte/JteViewRenderNullableRequestSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.jte
 import io.micronaut.core.io.Writable
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.views.ViewsRenderer
+import io.micronaut.views.jte.HtmlJteViewsRenderer
 import io.micronaut.views.jte.JteViewsRenderer
 import io.micronaut.views.jte.PlainJteViewsRenderer
 import jakarta.inject.Inject
@@ -15,7 +16,7 @@ class JteViewRenderNullableRequestSpec extends Specification {
     PlainJteViewsRenderer<?> plainJteViewsRenderer
 
     @Inject
-    PlainJteViewsRenderer<?> htmlJteViewsRenderer
+    HtmlJteViewsRenderer<?> htmlJteViewsRenderer
 
     void "views can be render with no request"() {
         expect:

--- a/views-jte/src/test/jte/dynamic.jte
+++ b/views-jte/src/test/jte/dynamic.jte
@@ -1,0 +1,8 @@
+@param String message
+
+<html>
+<head><title>Hello, ${message}</title></head>
+<body>
+<h1>Hello, ${message}</h1>
+</body>
+</html>


### PR DESCRIPTION
This is not completely polished but I wanted to share it for feedback.

For JTE - modifies where templates are loaded from when 'dynamic' is enabled, so that it can pick up 'src' changes.

TODO - still need to update the docs.