### PR TITLE
Polish docs.

### DIFF
--- a/views-freemarker/src/test/resources/views/home.ftl
+++ b/views-freemarker/src/test/resources/views/home.ftl
@@ -1,20 +1,3 @@
-<#--
-
-    Copyright 2017-2019 original authors
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
 <!DOCTYPE html>
 <html>
 <head>

--- a/views-freemarker/src/test/resources/views/invalid.ftl
+++ b/views-freemarker/src/test/resources/views/invalid.ftl
@@ -1,20 +1,3 @@
-<#--
-
-    Copyright 2017-2019 original authors
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
 <!DOCTYPE html>
 <html>
 <body>

--- a/views-thymeleaf/src/test/groovy/io/micronaut/docs/ViewsController.groovy
+++ b/views-thymeleaf/src/test/groovy/io/micronaut/docs/ViewsController.groovy
@@ -52,19 +52,19 @@ class ViewsController {
     @Get("/modelAndView")
     ModelAndView modelAndView() {
         return new ModelAndView("home",
-                new Person(loggedIn: true, username: 'sdelamo'))
+                new Person("sdelamo", true))
     }
     //end::modelAndView[]
 
     @Get("/home")
     HttpResponse<Person> home() {
-        HttpResponse.ok(new Person(loggedIn: true, username: 'sdelamo'))
+        HttpResponse.ok(new Person("sdelamo", true))
     }
 
     @View("bogus")
     @Get("/bogus")
     HttpResponse<Person> bogus() {
-        HttpResponse.ok(new Person(loggedIn: true, username: 'sdelamo'))
+        HttpResponse.ok(new Person("sdelamo", true))
     }
 
     @View("/home")


### PR DESCRIPTION
- make ViewsController.groovy compatible with Java
- remove license code from freemarker files

Docs include parts from `ViewsController.groovy` but say that it is a Java file. With this change the code is less confusing for someone not used to Groovy syntax and is **almost** compatible with Java - there are still missing semicolons.

Also the license header is removed from freemarker files as it clutters the docs (other template engines do not have license headers).