### PR TITLE
uncomment test

### DIFF
--- a/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerViewRendererSpec.groovy
+++ b/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerViewRendererSpec.groovy
@@ -48,7 +48,6 @@ class FreemarkerViewRendererSpec extends Specification {
     @AutoCleanup
     HttpClient client = embeddedServer.getApplicationContext().createBean(HttpClient, embeddedServer.getURL())
 
-    @PendingFeature
     def "bean is loaded"() {
         when:
         embeddedServer.applicationContext.getBean(FreemarkerViewsRenderer)


### PR DESCRIPTION
The test fails because in Micronaut 4 [`FreemarkerViewsRendererConfigurationProperties::setSettings`](https://github.com/micronaut-projects/micronaut-views/blob/master/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfigurationProperties.java#L138) is not invoked. We have to identify if there is a bug in core. 