### PR TITLE
bug: exclude transitive slf4j-api from thymleaf

### DIFF
--- a/views-thymeleaf/build.gradle
+++ b/views-thymeleaf/build.gradle
@@ -4,8 +4,12 @@ plugins {
 
 dependencies {
     api project(":views-core")
-    api(libs.managed.thymeleaf)
-    api(libs.thymeleaf.extras.java8time)
+    api(libs.managed.thymeleaf) {
+       exclude(group: "org.slf4j", module: "slf4j-api")
+    }
+    api(libs.thymeleaf.extras.java8time) {
+        exclude(group: "org.slf4j", module: "slf4j-api")
+    }
     compileOnly(mn.micronaut.management)
     compileOnly(mn.micronaut.validation)
 


### PR DESCRIPTION
./gradlew dependencies | grep slf4j

before:

|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |         +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |         +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|         +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5 (c)
|    |    \--- org.slf4j:slf4j-api:1.7.32 -> 2.0.5
|    |    \--- org.slf4j:slf4j-api:1.7.25 -> 2.0.5
|    |    \--- org.slf4j:slf4j-api:1.7.7 -> 2.0.5
|    |    \--- org.slf4j:slf4j-api:2.0.5
|    |    \--- org.slf4j:slf4j-api:1.7.25 -> 2.0.5
     |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.5
|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |         +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |         +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5 (c)
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.5
|    |    \--- org.slf4j:slf4j-api:1.7.32 -> 2.0.5
|    |    \--- org.slf4j:slf4j-api:1.7.25 -> 2.0.5
|    |    \--- org.slf4j:slf4j-api:1.7.7 -> 2.0.5
|    |    \--- org.slf4j:slf4j-api:2.0.5
|    |    \--- org.slf4j:slf4j-api:1.7.25 -> 2.0.5
     |    \--- org.slf4j:slf4j-api:1.7.30 -> 2.0.5

after:

 ./gradlew dependencies | grep slf4j
|    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    \--- org.slf4j:slf4j-api:1.7.36
|    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |         +--- org.slf4j:slf4j-api:1.7.36
|    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |         +--- org.slf4j:slf4j-api:1.7.36
|         +--- org.slf4j:slf4j-api:1.7.36 (c)
|    |    \--- org.slf4j:slf4j-api:1.7.32 -> 1.7.36
|    |    \--- org.slf4j:slf4j-api:1.7.25 -> 1.7.36
|    |    \--- org.slf4j:slf4j-api:1.7.7 -> 1.7.36
     |    \--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
|    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    \--- org.slf4j:slf4j-api:1.7.36
|    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |         +--- org.slf4j:slf4j-api:1.7.36
|    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |         +--- org.slf4j:slf4j-api:1.7.36
|    |    |    +--- org.slf4j:slf4j-api:1.7.36 (c)
|    |    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    +--- org.slf4j:slf4j-api:1.7.36
|    |    \--- org.slf4j:slf4j-api:1.7.32 -> 1.7.36
|    |    \--- org.slf4j:slf4j-api:1.7.25 -> 1.7.36
|    |    \--- org.slf4j:slf4j-api:1.7.7 -> 1.7.36
     |    \--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36