### PR TITLE
Rendering failure with ViewRenderingException fails with ReadTimeoutException

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 managed-freemarker = "2.3.31"
 managed-handlebars = "4.3.1"
-managed-jte = "2.2.4"
+managed-jte = "2.3.0"
 managed-rocker = "1.3.0"
 managed-soy = "2022-03-02"
 managed-thymeleaf = "3.1.1.RELEASE"

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/soy/CustomSoyFileSetProvider.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/soy/CustomSoyFileSetProvider.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.doc.soy
+package io.micronaut.docs.soy
 
 import com.google.template.soy.SoyFileSet
 import io.micronaut.context.annotation.Requires

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/soy/SoySpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/soy/SoySpec.groovy
@@ -11,7 +11,9 @@ import spock.lang.Specification
 
 import jakarta.inject.Inject
 
+@Property(name = "micronaut.security.enabled", value = StringUtils.FALSE)
 @Property(name = "spec.name", value = "soy")
+@Property(name = "micronaut.views.velocity.enabled", value = StringUtils.FALSE)
 @MicronautTest
 class SoySpec extends Specification {
     @Inject

--- a/views-core/src/main/java/io/micronaut/views/ViewsFilter.java
+++ b/views-core/src/main/java/io/micronaut/views/ViewsFilter.java
@@ -31,6 +31,7 @@ import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.http.filter.ServerFilterPhase;
 import io.micronaut.views.exceptions.ViewNotFoundException;
+import io.micronaut.views.exceptions.ViewRenderingException;
 import io.micronaut.views.turbo.DefaultTurboFrameRenderer;
 import io.micronaut.views.turbo.DefaultTurboStreamRenderer;
 import io.micronaut.views.turbo.TurboFrame;
@@ -43,6 +44,7 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
+
 import java.util.Optional;
 
 /**
@@ -175,7 +177,7 @@ public class ViewsFilter implements HttpServerFilter {
                     response.contentType(type);
                     response.body(writable);
                     return Flux.just(response);
-                } catch (ViewNotFoundException e) {
+                } catch (ViewNotFoundException | ViewRenderingException e) {
                     return Flux.error(e);
                 }
             });

--- a/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerViewRendererSpec.groovy
+++ b/views-freemarker/src/test/groovy/io/micronaut/docs/FreemarkerViewRendererSpec.groovy
@@ -22,12 +22,12 @@ import io.micronaut.http.MediaType
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientException
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.exceptions.ReadTimeoutException
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.views.ViewsFilter
 import io.micronaut.views.freemarker.FreemarkerViewsRenderer
 import io.micronaut.views.freemarker.FreemarkerViewsRendererConfigurationProperties
 import spock.lang.AutoCleanup
-import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -194,15 +194,16 @@ class FreemarkerViewRendererSpec extends Specification {
         rsp.body().contains("<h1>You are not logged in</h1>")
     }
 
-    def "invoking /freemarker/invalid returns error"() {
+    def "invoking /freemarker/invalid throws HttpClientException that is not a read timeout"() {
         when:
         client.toBlocking().exchange('/freemarker/invalid', String)
 
         then:
-         thrown(HttpClientException)
+        def e = thrown(HttpClientException)
+        // 'https://github.com/micronaut-projects/micronaut-views/issues/478'
+        !(e instanceof ReadTimeoutException)
     }
 
-    @PendingFeature
     def "invoking /freemarker/invalid returns HttpClientResponseException with 500 as status code"() {
         when:
         client.toBlocking().exchange('/freemarker/invalid', String)

--- a/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRenderer.java
+++ b/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRenderer.java
@@ -33,6 +33,8 @@ import io.micronaut.core.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
+import java.io.IOException;
+
 /**
  * Renders Views with with Handlebars.java.
  *
@@ -76,10 +78,15 @@ public class HandlebarsViewsRenderer<T> implements ViewsRenderer<T> {
                            @Nullable T data,
                            @Nullable HttpRequest<?> request) {
         ArgumentUtils.requireNonNull("viewName", viewName);
+        String location = viewLocation(viewName);
+        Template template;
+        try {
+            template = handlebars.compile(location);
+        } catch (IOException e) {
+            throw new ViewRenderingException("Error rendering Handlebars view [" + viewName + "]: " + e.getMessage(), e);
+        }
         return (writer) -> {
-            String location = viewLocation(viewName);
             try {
-                Template template = handlebars.compile(location);
                 template.apply(data, writer);
             } catch (Throwable e) {
                 throw new ViewRenderingException("Error rendering Handlebars view [" + viewName + "]: " + e.getMessage(), e);

--- a/views-handlebars/src/test/groovy/io/micronaut/docs/HandlebarsController.groovy
+++ b/views-handlebars/src/test/groovy/io/micronaut/docs/HandlebarsController.groovy
@@ -61,4 +61,9 @@ public class HandlebarsController {
     HttpResponse nullBody() {
         HttpResponse.ok()
     }
+
+    @View("badsyntax.hbs")
+    @Get("/badsyntax")
+    void badsyntax() {
+    }
 }

--- a/views-handlebars/src/test/groovy/io/micronaut/docs/HandlebarsViewsRendererSpec.groovy
+++ b/views-handlebars/src/test/groovy/io/micronaut/docs/HandlebarsViewsRendererSpec.groovy
@@ -20,11 +20,14 @@ import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientException
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.exceptions.ReadTimeoutException
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.views.ViewsFilter
 import io.micronaut.views.handlebars.HandlebarsViewsRenderer
 import spock.lang.AutoCleanup
+import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -55,6 +58,16 @@ class HandlebarsViewsRendererSpec extends Specification {
 
         then:
         noExceptionThrown()
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-views/issues/478')
+    def "invoking /handlebars/badsyntax throws HttpClientException that is not a read timeout"() {
+        when:
+        HttpResponse<String> rsp = client.toBlocking().exchange('/handlebars/badsyntax', String)
+
+        then:
+        def e = thrown(HttpClientException)
+        !(e instanceof ReadTimeoutException)
     }
 
     def "invoking /handlebars/home does not specify @View, thus, regular JSON rendering is used"() {

--- a/views-handlebars/src/test/resources/views/badsyntax.hbs
+++ b/views-handlebars/src/test/resources/views/badsyntax.hbs
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Home</title>
+</head>
+<body>
+    {{#if loggedIn}}
+    <h1>username: <span>{{username}}</span></h1>
+    {{else}}
+    <h1>You are not logged in</h1>
+    {{/badsyntax}}
+</body>
+</html>

--- a/views-jte/src/test/groovy/io/micronaut/docs/JteController.groovy
+++ b/views-jte/src/test/groovy/io/micronaut/docs/JteController.groovy
@@ -95,4 +95,9 @@ class JteController {
     HttpResponse kteTemplate() {
         return HttpResponse.ok(CollectionUtils.mapOf("loggedIn", true, "username", "sdelamo"));
     }
+
+    @View("badsyntax.hbs")
+    @Get("/badsyntax")
+    void badsyntax() {
+    }
 }

--- a/views-jte/src/test/groovy/io/micronaut/docs/JteViewRendererSpec.groovy
+++ b/views-jte/src/test/groovy/io/micronaut/docs/JteViewRendererSpec.groovy
@@ -20,11 +20,14 @@ import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientException
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.exceptions.ReadTimeoutException
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.views.ViewsFilter
 import io.micronaut.views.jte.JteViewsRenderer
 import spock.lang.AutoCleanup
+import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -50,6 +53,16 @@ abstract class JteViewRendererSpec extends Specification {
         then:
         noExceptionThrown()
         !jteBeans.empty
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-views/issues/478')
+    def "invoking /jte/badsyntax throws HttpClientException that is not a read timeout"() {
+        when:
+        HttpResponse<String> rsp = client.toBlocking().exchange('/jte/badsyntax', String)
+
+        then:
+        def e = thrown(HttpClientException)
+        !(e instanceof ReadTimeoutException)
     }
 
     def "invoking /jte/home does not specify @View, thus, regular JSON rendering is used"() {

--- a/views-jte/src/test/resources/views/badsyntax.jte
+++ b/views-jte/src/test/resources/views/badsyntax.jte
@@ -1,0 +1,14 @@
+@param Boolean loggedIn
+@param String username
+<html>
+    <head>
+        <title>Home</title>
+    </head>
+    <body>
+        @if (loggedIn != null && loggedIn)
+            <h1>username: <span>${username}</span></h1>
+        @else
+            <h1>You are not logged in</h1>
+        @endif
+    </body>
+</html>

--- a/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleViewsRenderer.java
+++ b/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleViewsRenderer.java
@@ -99,10 +99,10 @@ public class PebbleViewsRenderer<T> implements ViewsRenderer<T> {
         try {
             // this has to fail fast to avoid a ReadTimeoutException from ViewsFilter call
             template = engine.getTemplate(name);
-        } catch (Throwable e) {
+        } catch (Exception e) {
             throw new ViewRenderingException("Error rendering Pebble view [" + name + "]: " + e.getMessage(), e);
         }
-        return (writer) -> template.evaluate(writer, ViewUtils.modelOf(data),
+        return writer -> template.evaluate(writer, ViewUtils.modelOf(data),
                     request != null ? httpLocaleResolver.resolveOrDefault(request) : Locale.getDefault());
     }
 

--- a/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleViewsRenderer.java
+++ b/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleViewsRenderer.java
@@ -16,6 +16,7 @@
 package io.micronaut.views.pebble;
 
 import com.mitchellbosecke.pebble.PebbleEngine;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
@@ -25,6 +26,7 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.views.ViewUtils;
 import io.micronaut.views.ViewsRenderer;
+import io.micronaut.views.exceptions.ViewRenderingException;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -93,7 +95,15 @@ public class PebbleViewsRenderer<T> implements ViewsRenderer<T> {
     public Writable render(@NonNull String name,
                            @Nullable T data,
                            @Nullable HttpRequest<?> request) {
-        return (writer) -> engine.getTemplate(name).evaluate(writer, ViewUtils.modelOf(data), request != null ? httpLocaleResolver.resolveOrDefault(request) : Locale.getDefault());
+        PebbleTemplate template;
+        try {
+            // this has to fail fast to avoid a ReadTimeoutException from ViewsFilter call
+            template = engine.getTemplate(name);
+        } catch (Throwable e) {
+            throw new ViewRenderingException("Error rendering Pebble view [" + name + "]: " + e.getMessage(), e);
+        }
+        return (writer) -> template.evaluate(writer, ViewUtils.modelOf(data),
+                    request != null ? httpLocaleResolver.resolveOrDefault(request) : Locale.getDefault());
     }
 
     @Override

--- a/views-pebble/src/test/groovy/io/micronaut/docs/PebbleController.groovy
+++ b/views-pebble/src/test/groovy/io/micronaut/docs/PebbleController.groovy
@@ -72,4 +72,9 @@ public class PebbleController {
     @Get("/i18n")
     void i18n() {
     }
+
+    @View("badsyntax.html")
+    @Get("/badsyntax")
+    void badsyntax() {
+    }
 }

--- a/views-pebble/src/test/groovy/io/micronaut/docs/PebbleViewsRendererSpec.groovy
+++ b/views-pebble/src/test/groovy/io/micronaut/docs/PebbleViewsRendererSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.docs
 
+import com.mitchellbosecke.pebble.error.ParserException
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
@@ -25,6 +26,7 @@ import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.views.ViewsFilter
 import io.micronaut.views.pebble.PebbleViewsRenderer
 import spock.lang.AutoCleanup
+import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -139,6 +141,15 @@ class PebbleViewsRendererSpec extends Specification {
         then:
         body
         rsp.body().contains("<h1>You are not logged in</h1>")
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-views/issues/478')
+    def "invoking /pebble/badsyntax throws pebble ParserException"() {
+        when:
+        HttpResponse<String> rsp = client.toBlocking().exchange('/pebble/badsyntax', String)
+
+        then:
+        thrown(ParserException)
     }
 
     def "invoking /text renders pebble text template from a controller returning a map"() {

--- a/views-pebble/src/test/groovy/io/micronaut/docs/PebbleViewsRendererSpec.groovy
+++ b/views-pebble/src/test/groovy/io/micronaut/docs/PebbleViewsRendererSpec.groovy
@@ -15,13 +15,15 @@
  */
 package io.micronaut.docs
 
-import com.mitchellbosecke.pebble.error.ParserException
+
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientException
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.exceptions.ReadTimeoutException
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.views.ViewsFilter
 import io.micronaut.views.pebble.PebbleViewsRenderer
@@ -144,12 +146,13 @@ class PebbleViewsRendererSpec extends Specification {
     }
 
     @Issue('https://github.com/micronaut-projects/micronaut-views/issues/478')
-    def "invoking /pebble/badsyntax throws pebble ParserException"() {
+    def "invoking /pebble/badsyntax throws HttpClientException that is not a read timeout"() {
         when:
         HttpResponse<String> rsp = client.toBlocking().exchange('/pebble/badsyntax', String)
 
         then:
-        thrown(ParserException)
+        def e = thrown(HttpClientException)
+        !(e instanceof ReadTimeoutException)
     }
 
     def "invoking /text renders pebble text template from a controller returning a map"() {

--- a/views-pebble/src/test/resources/views/badsyntax.html
+++ b/views-pebble/src/test/resources/views/badsyntax.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Home</title>
+</head>
+<body>
+    {% block header %}
+    <h1> Introduction </h1>
+    {% endlock header %}
+</body>
+</html>

--- a/views-soy/src/main/java/io/micronaut/views/soy/SoySauceViewsRenderer.java
+++ b/views-soy/src/main/java/io/micronaut/views/soy/SoySauceViewsRenderer.java
@@ -18,6 +18,7 @@ package io.micronaut.views.soy;
 import com.google.template.soy.SoyFileSet;
 import com.google.template.soy.data.SoyTemplate;
 import com.google.template.soy.data.SoyValueProvider;
+import com.google.template.soy.error.SoyCompilationException;
 import com.google.template.soy.jbcsrc.api.RenderResult;
 import com.google.template.soy.jbcsrc.api.SoySauce;
 import com.google.template.soy.shared.SoyCssRenamingMap;
@@ -91,7 +92,12 @@ public class SoySauceViewsRenderer<T> implements ViewsRenderer<T> {
                 throw new IllegalStateException(
                         "Unable to load Soy templates: no file set, no compiled templates provided.");
             }
-            this.soySauce = soyConfiguration.getFileSet().compileTemplates();
+            try {
+                this.soySauce = soyConfiguration.getFileSet().compileTemplates();
+            } catch (SoyCompilationException se) {
+                throw new ViewRenderingException(
+                    "Soy template compilation failed: " + se.getMessage(), se);
+            }
         }
     }
 

--- a/views-soy/src/main/java/io/micronaut/views/soy/SoySauceViewsRenderer.java
+++ b/views-soy/src/main/java/io/micronaut/views/soy/SoySauceViewsRenderer.java
@@ -93,7 +93,7 @@ public class SoySauceViewsRenderer<T> implements ViewsRenderer<T> {
                         "Unable to load Soy templates: no file set, no compiled templates provided.");
             }
             try {
-                this.soySauce = soyConfiguration.getFileSet().compileTemplates();
+                this.soySauce = fileSet.compileTemplates();
             } catch (SoyCompilationException se) {
                 throw new ViewRenderingException(
                     "Soy template compilation failed: " + se.getMessage(), se);

--- a/views-soy/src/test/groovy/io/micronaut/docs/BadSyntaxSoyController.groovy
+++ b/views-soy/src/test/groovy/io/micronaut/docs/BadSyntaxSoyController.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.docs
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.views.View
+
+@Requires(property = "spec.name", value = "badsyntax")
+@Controller("/badsyntax")
+class BadSyntaxSoyController {
+
+    @View("fail.badsyntax")
+    @Get("/")
+    void badsyntax() {
+    }
+}

--- a/views-soy/src/test/groovy/io/micronaut/docs/BadSyntaxSoyFileSetProvider.groovy
+++ b/views-soy/src/test/groovy/io/micronaut/docs/BadSyntaxSoyFileSetProvider.groovy
@@ -4,19 +4,18 @@ import com.google.template.soy.SoyFileSet
 import io.micronaut.context.annotation.Requires
 import io.micronaut.views.ViewsConfiguration
 import io.micronaut.views.soy.SoyFileSetProvider
-
 import jakarta.inject.Singleton
-
 
 /**
  * Provide a SoyFileSet
  */
 @Singleton
-@Requires(property = "spec.name", value = "soy")
-class ExampleSoyFileSetProvider implements SoyFileSetProvider {
+@Requires(property = "spec.name", value = "badsyntax")
+class BadSyntaxSoyFileSetProvider implements SoyFileSetProvider {
 
     private final ViewsConfiguration viewsConfiguration
-    ExampleSoyFileSetProvider(ViewsConfiguration viewsConfiguration) {
+
+    BadSyntaxSoyFileSetProvider(ViewsConfiguration viewsConfiguration) {
         this.viewsConfiguration = viewsConfiguration
     }
     /**
@@ -26,7 +25,7 @@ class ExampleSoyFileSetProvider implements SoyFileSetProvider {
     SoyFileSet provideSoyFileSet() {
         return SoyFileSet.builder()
             .add(new File(
-                ExampleSoyFileSetProvider.class.getClassLoader().getResource(viewsConfiguration.getFolder() + "/home.soy").getFile()))
+                BadSyntaxSoyFileSetProvider.class.getClassLoader().getResource(viewsConfiguration.getFolder() + "/badsyntax.soy").getFile()))
         .build()
     }
 }

--- a/views-soy/src/test/groovy/io/micronaut/docs/SoySauceViewRendererBadsyntaxSpec.groovy
+++ b/views-soy/src/test/groovy/io/micronaut/docs/SoySauceViewRendererBadsyntaxSpec.groovy
@@ -1,0 +1,43 @@
+package io.micronaut.docs
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientException
+import io.micronaut.http.client.exceptions.ReadTimeoutException
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+class SoySauceViewRendererBadsyntaxSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+    [
+            "spec.name": "badsyntax",
+            "micronaut.security.enabled": false,
+            "micronaut.views.soy.engine": "sauce",
+            'micronaut.views.csp.enabled': true,
+            'micronaut.views.csp.generateNonce': true,
+            'micronaut.views.csp.reportOnly': false,
+            'micronaut.views.csp.policyDirectives': "default-src self:; script-src 'nonce-{#nonceValue}';"
+    ],
+    "test")
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = embeddedServer.getApplicationContext().createBean(HttpClient, embeddedServer.getURL())
+
+    @Issue('https://github.com/micronaut-projects/micronaut-views/issues/478')
+    def "invoking /soy/badsyntax throws HttpClientException that is not a read timeout"() {
+        when:
+        HttpResponse<String> rsp = client.toBlocking().exchange('/badsyntax', String)
+
+        then:
+        def e = thrown(HttpClientException)
+        !(e instanceof ReadTimeoutException)
+    }
+}

--- a/views-soy/src/test/groovy/io/micronaut/views/soy/SoyViewRenderNullableRequestSpec.groovy
+++ b/views-soy/src/test/groovy/io/micronaut/views/soy/SoyViewRenderNullableRequestSpec.groovy
@@ -1,11 +1,13 @@
 package io.micronaut.views.soy
 
+import io.micronaut.context.annotation.Property
 import io.micronaut.core.io.Writable
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification
 
 @MicronautTest(startApplication = false)
+@Property(name = "spec.name", value = "soy")
 class SoyViewRenderNullableRequestSpec extends Specification {
 
     @Inject

--- a/views-soy/src/test/resources/views/badsyntax.soy
+++ b/views-soy/src/test/resources/views/badsyntax.soy
@@ -1,0 +1,10 @@
+{namespace fail}
+
+// Sample template.
+{template .badsyntax}
+  {if $loggedIn}
+      <h1>username: <span>{$username}</span></h1>
+  {else}
+      <h1>You are not logged in</h1>
+  {/badsyntax}
+{/template}

--- a/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRenderer.java
+++ b/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRenderer.java
@@ -100,7 +100,7 @@ public class VelocityViewsRenderer<T> implements ViewsRenderer<T> {
         try {
             velocityEngine.getTemplate(viewName(viewName));
         } catch (ResourceNotFoundException | ParseErrorException e) {
-            return false;
+            throw new ViewRenderingException("Error rendering Velocity view [" + viewName + "]: " + e.getMessage(), e);
         }
         return true;
     }

--- a/views-velocity/src/test/groovy/io/micronaut/docs/VelocityController.groovy
+++ b/views-velocity/src/test/groovy/io/micronaut/docs/VelocityController.groovy
@@ -82,4 +82,9 @@ class VelocityController {
     HttpResponse nullBody() {
         HttpResponse.ok()
     }
+
+    @View("badsyntax.vm")
+    @Get("/badsyntax")
+    void badsyntax() {
+    }
 }

--- a/views-velocity/src/test/groovy/io/micronaut/docs/VelocityViewRendererSpec.groovy
+++ b/views-velocity/src/test/groovy/io/micronaut/docs/VelocityViewRendererSpec.groovy
@@ -20,11 +20,14 @@ import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientException
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.exceptions.ReadTimeoutException
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.views.ViewsFilter
 import io.micronaut.views.velocity.VelocityViewsRenderer
 import spock.lang.AutoCleanup
+import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -50,6 +53,16 @@ class VelocityViewRendererSpec extends Specification {
 
         then:
         noExceptionThrown()
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-views/issues/478')
+    def "invoking /velocity/badsyntax throws HttpClientException that is not a read timeout"() {
+        when:
+        HttpResponse<String> rsp = client.toBlocking().exchange('/velocity/badsyntax', String)
+
+        then:
+        def e = thrown(HttpClientException)
+        !(e instanceof ReadTimeoutException)
     }
 
     def "invoking /velocity/home does not specify @View, thus, regular JSON rendering is used"() {

--- a/views-velocity/src/test/resources/views/badsyntax.vm
+++ b/views-velocity/src/test/resources/views/badsyntax.vm
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Home</title>
+</head>
+<body>
+    #if( $loggedIn )
+    <h1>username: <span>$username</span></h1>
+    #else
+    <h1>You are not logged in</h1>
+    #badsyntax
+</body>
+</html>


### PR DESCRIPTION
fixes #478

This was more of a problem than that described by the original issue. The root problem is that template compilation was occurring after `ViewsFilter.doFilter()` returned so `Flux.error()` wasn't returned when it should have been. That resulted in the template rendering endpoints stalling and eventually raising a `ReadTimeoutException`. 

I have changed all the templating engine implementations to parse/compile the template before `doFilter()` returns so that it fails fast. I also made them more consistent in failure behavior (e.g. using `ViewRenderingException` as the cause). The one thing I'm not certain about is if it will be a problem with reactive response for large/complex templates.

I added/revised tests to make sure expected `HttpClientException` exceptions on failed syntax aren't actually `ReadTimeoutException`.

This doesn't apply to Rocker templates, since template errors fail at compile time. I didn't change Velocity either since it doesn't seem to care about errors and just renders garbage without raising an exception like the other engines do.