### PR TITLE
Use records for the fieldset objects

### DIFF
--- a/views-fieldset/src/main/java/io/micronaut/views/fields/Checkbox.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/Checkbox.java
@@ -21,135 +21,29 @@ import io.micronaut.core.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A Checkbox Form Element.
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox">Input Checkbox</a>
+ * @param name Name of the form control. Submitted with the form as part of a name/value pair
+ * @param value A string representing the value of the checkbox.
+ * @param checked A boolean attribute indicating whether this checkbox is checked by default (when the page loads).
+ * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param label represents a caption for an item in a user interface
+ * @param errors Form element validation Errors.
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = Checkbox.Builder.class))
-public class Checkbox implements FormElement, GlobalAttributes, FormElementAttributes {
-
-    @NonNull
-    private final String name;
-
-    @NonNull
-    private final String value;
-
-    private final boolean checked;
-
-    private final boolean required;
-
-    @Nullable
-    private final String id;
-
-    @Nullable
-    private final Message label;
-
-    @NonNull
-    private final List<Message> errors;
-
-    /**
-     *
-     * @param name Name of the form control. Submitted with the form as part of a name/value pair
-     * @param value A string representing the value of the checkbox.
-     * @param checked A boolean attribute indicating whether this checkbox is checked by default (when the page loads).
-     * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param label represents a caption for an item in a user interface
-     * @param errors Form element validation Errors.
-     */
-    public Checkbox(@NonNull String name,
-                    String value,
-                    boolean checked,
-                    boolean required,
-                    @Nullable String id,
-                    @Nullable Message label,
-                    @NonNull List<Message> errors) {
-        this.name = name;
-        this.value = value;
-        this.checked = checked;
-        this.required = required;
-        this.id = id;
-        this.label = label;
-        this.errors = errors;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    @Override
-    @NonNull
-    public String getName() {
-        return name;
-    }
-
-    /**
-     *
-     * @return A string representing the value of the checkbox.
-     */
-    @NonNull
-    public String getValue() {
-        return value;
-    }
-
-    /**
-     *
-     * @return A boolean attribute indicating whether this checkbox is checked by default (when the page loads).
-     */
-    public boolean isChecked() {
-        return checked;
-    }
-
-    @Override
-    @Nullable
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    @Nullable
-    public Message getLabel() {
-        return label;
-    }
-
-    @Override
-    @NonNull
-    public List<Message> getErrors() {
-        return errors;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Checkbox checkbox)) return false;
-
-        if (checked != checkbox.checked) return false;
-        if (required != checkbox.required) return false;
-        if (!Objects.equals(name, checkbox.name)) return false;
-        if (!Objects.equals(value, checkbox.value)) return false;
-        if (!Objects.equals(id, checkbox.id)) return false;
-        if (!Objects.equals(label, checkbox.label)) return false;
-        return Objects.equals(errors, checkbox.errors);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (checked ? 1 : 0);
-        result = 31 * result + (required ? 1 : 0);
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        result = 31 * result + (errors != null ? errors.hashCode() : 0);
-        return result;
-    }
+public record Checkbox(@NonNull String name,
+                       @NonNull String value,
+                       boolean checked,
+                       boolean required,
+                       @Nullable String id,
+                       @Nullable Message label,
+                       @NonNull List<Message> errors) implements FormElement, GlobalAttributes, FormElementAttributes {
 
     /**
      *

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/ConstraintViolationMessage.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/ConstraintViolationMessage.java
@@ -18,31 +18,30 @@ package io.micronaut.views.fields;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import jakarta.validation.ConstraintViolation;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 /**
  * {@link Message} implementation backed by a {@link ConstraintViolation}.
+ * @param defaultMessage The default message to use if no code is specified or no localized message found.
+ * @param code The i18n code which can be used to fetch a localized message.
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected
-public class ConstraintViolationMessage implements Message {
-    private static final String DOT = ".";
-    @NonNull
-    private final String code;
+public record ConstraintViolationMessage(@NonNull String code, @NonNull String defaultMessage) implements Message {
 
-    @NonNull
-    private final String defaultMessage;
+    private static final String DOT = ".";
 
     /**
      *
      * @param constraintViolation Constraint Violation.
      */
     public ConstraintViolationMessage(ConstraintViolation<?> constraintViolation) {
-        this.code = code(constraintViolation);
-        this.defaultMessage = constraintViolation.getMessage();
+        this(code(constraintViolation), constraintViolation.getMessage());
     }
 
     @SuppressWarnings("NeedBraces")
@@ -51,11 +50,10 @@ public class ConstraintViolationMessage implements Message {
         if (this == o) return true;
         if (!(o instanceof Message that)) return false;
 
-        if (!Objects.equals(code, that.getCode())) return false;
-        return Objects.equals(defaultMessage, that.getDefaultMessage());
+        if (!Objects.equals(code, that.code())) return false;
+        return Objects.equals(defaultMessage, that.defaultMessage());
     }
 
-    @SuppressWarnings("NeedBraces")
     @Override
     public int hashCode() {
         int result = code != null ? code.hashCode() : 0;
@@ -63,19 +61,7 @@ public class ConstraintViolationMessage implements Message {
         return result;
     }
 
-    @Override
-    @NonNull
-    public String getCode() {
-        return code;
-    }
-
-    @Override
-    @NonNull
-    public String getDefaultMessage() {
-        return defaultMessage;
-    }
-
-    private String code(ConstraintViolation<?> violation) {
+    private static String code(ConstraintViolation<?> violation) {
         List<String> parts = new ArrayList<>();
         parts.add(violation.getLeafBean().getClass().getSimpleName());
         ConstraintViolationUtils.lastNode(violation).ifPresent(parts::add);

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/FormElementAttributes.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/FormElementAttributes.java
@@ -32,19 +32,19 @@ public interface FormElementAttributes {
      * @return Name of the form control. Submitted with the form as part of a name/value pair
      */
     @NonNull
-    String getName();
+    String name();
 
     /**
      *
      * @return represents a caption for an item in a user interface
      */
     @Nullable
-    Message getLabel();
+    Message label();
 
     /**
      *
      * @return Form element validation Errors.
      */
     @NonNull
-    List<Message> getErrors();
+    List<Message> errors();
 }

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/GlobalAttributes.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/GlobalAttributes.java
@@ -29,12 +29,12 @@ public interface GlobalAttributes {
      * @return It defines an identifier (ID) which must be unique in the whole document
      */
     @Nullable
-    String getId();
+    String id();
 
 
     /**
      *
      * @return If true indicates that the user must specify a value for the input before the owning form can be submitted.
      */
-    boolean isRequired();
+    boolean required();
 }

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/InputDateFormElement.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/InputDateFormElement.java
@@ -22,153 +22,31 @@ import io.micronaut.core.annotation.Nullable;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Input Date.
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date">Input date</a>
+ * @param name Name of the form control. Submitted with the form as part of a name/value pair
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
+ * @param max The latest date to accept
+ * @param min The earliest date to accept.
+ * @param value the input date value
+ * @param label represents a caption for an item in a user interface
+ * @param errors Form element validation Errors.
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = InputDateFormElement.Builder.class))
-public class InputDateFormElement implements FormElement, GlobalAttributes, FormElementAttributes {
-    @NonNull
-    private final String name;
-
-    @Nullable
-    private final String id;
-
-    @Nullable
-    private final LocalDate min;
-
-    @Nullable
-    private final LocalDate max;
-
-    private final boolean required;
-
-    @Nullable
-    private final LocalDate value;
-
-    @Nullable
-    private final Message label;
-
-    @NonNull
-    private final List<Message> errors;
-
-    /**
-     *
-     * @param name Name of the form control. Submitted with the form as part of a name/value pair
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     * @param max The latest date to accept
-     * @param min The earliest date to accept.
-     * @param value the input date value
-     * @param label represents a caption for an item in a user interface
-     * @param errors Form element validation Errors.
-     */
-    public InputDateFormElement(@NonNull String name,
-                                     @NonNull String id,
-                                     boolean required,
-                                     @Nullable LocalDate max,
-                                     @Nullable LocalDate min,
-                                     @Nullable LocalDate value,
-                                     @Nullable Message label,
-                                     @NonNull List<Message> errors) {
-        this.name = name;
-        this.id = id;
-        this.required = required;
-        this.max = max;
-        this.min = min;
-        this.value = value;
-        this.label = label;
-        this.errors = errors;
-    }
-
-    @Override
-    @NonNull
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    @Nullable
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    /**
-     *
-     * @return The latest date to accept
-     */
-    @Nullable
-    public LocalDate getMax() {
-        return max;
-    }
-
-    /**
-     *
-     * @return The earliest date to accept.
-     */
-    @Nullable
-    public LocalDate getMin() {
-        return min;
-    }
-
-    /**
-     *
-     * @return the input date value
-     */
-    @Nullable
-    public LocalDate getValue() {
-        return value;
-    }
-
-    @Override
-    @Nullable
-    public Message getLabel() {
-        return label;
-    }
-
-    @Override
-    @NonNull
-    public List<Message> getErrors() {
-        return errors;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof InputDateFormElement that)) return false;
-
-        if (required != that.required) return false;
-        if (!Objects.equals(name, that.name)) return false;
-        if (!Objects.equals(id, that.id)) return false;
-        if (!Objects.equals(min, that.min)) return false;
-        if (!Objects.equals(max, that.max)) return false;
-        if (!Objects.equals(value, that.value)) return false;
-        if (!Objects.equals(label, that.label)) return false;
-        return Objects.equals(errors, that.errors);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (min != null ? min.hashCode() : 0);
-        result = 31 * result + (max != null ? max.hashCode() : 0);
-        result = 31 * result + (required ? 1 : 0);
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        result = 31 * result + (errors != null ? errors.hashCode() : 0);
-        return result;
-    }
+public record InputDateFormElement(@NonNull String name,
+                                   @NonNull String id,
+                                   boolean required,
+                                   @Nullable LocalDate max,
+                                   @Nullable LocalDate min,
+                                   @Nullable LocalDate value,
+                                   @Nullable Message label,
+                                   @NonNull List<Message> errors) implements FormElement, GlobalAttributes, FormElementAttributes {
 
     /**
      *

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/InputDateTimeLocalFormElement.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/InputDateTimeLocalFormElement.java
@@ -22,152 +22,30 @@ import io.micronaut.core.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local">Input datetime-local</a>
+ * @param name Name of the form control. Submitted with the form as part of a name/value pair
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
+ * @param max The latest date and time to accept
+ * @param min The earliest date and time to accept
+ * @param value The value of the Input Datetime Local
+ * @param label represents a caption for an item in a user interface
+ * @param errors Form element validation Errors.
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = InputDateTimeLocalFormElement.Builder.class))
-public class InputDateTimeLocalFormElement implements FormElement, GlobalAttributes, FormElementAttributes {
-    @NonNull
-    private final String name;
-
-    @Nullable
-    private final String id;
-
-    @Nullable
-    private final LocalDateTime min;
-
-    @Nullable
-    private final LocalDateTime max;
-
-    private final boolean required;
-
-    @Nullable
-    private final LocalDateTime value;
-
-    @Nullable
-    private final Message label;
-
-    @NonNull
-    private final List<Message> errors;
-
-    /**
-     *
-     * @param name Name of the form control. Submitted with the form as part of a name/value pair
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     * @param max The latest date and time to accept
-     * @param min The earliest date and time to accept
-     * @param value The value of the Input Datetime Local
-     * @param label represents a caption for an item in a user interface
-     * @param errors Form element validation Errors.
-     */
-    public InputDateTimeLocalFormElement(@NonNull String name,
-                                         @NonNull String id,
-                                         boolean required,
-                                         @Nullable LocalDateTime max,
-                                         @Nullable LocalDateTime min,
-                                         @Nullable LocalDateTime value,
-                                         @Nullable Message label,
-                                         @NonNull List<Message> errors) {
-        this.name = name;
-        this.id = id;
-        this.required = required;
-        this.max = max;
-        this.min = min;
-        this.value = value;
-        this.label = label;
-        this.errors = errors;
-    }
-
-    @Override
-    @NonNull
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    @Nullable
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    /**
-     *
-     * @return The latest date and time to accept
-     */
-    @Nullable
-    public LocalDateTime getMax() {
-        return max;
-    }
-
-    /**
-     *
-     * @return The earliest date and time to accept
-     */
-    @Nullable
-    public LocalDateTime getMin() {
-        return min;
-    }
-
-    /**
-     *
-     * @return The value of the Input Datetime Local
-     */
-    @Nullable
-    public LocalDateTime getValue() {
-        return value;
-    }
-
-    @Override
-    @Nullable
-    public Message getLabel() {
-        return label;
-    }
-
-    @Override
-    @NonNull
-    public List<Message> getErrors() {
-        return errors;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof InputDateTimeLocalFormElement that)) return false;
-
-        if (required != that.required) return false;
-        if (!Objects.equals(name, that.name)) return false;
-        if (!Objects.equals(id, that.id)) return false;
-        if (!Objects.equals(min, that.min)) return false;
-        if (!Objects.equals(max, that.max)) return false;
-        if (!Objects.equals(value, that.value)) return false;
-        if (!Objects.equals(label, that.label)) return false;
-        return Objects.equals(errors, that.errors);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (min != null ? min.hashCode() : 0);
-        result = 31 * result + (max != null ? max.hashCode() : 0);
-        result = 31 * result + (required ? 1 : 0);
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        result = 31 * result + (errors != null ? errors.hashCode() : 0);
-        return result;
-    }
+public record InputDateTimeLocalFormElement(@NonNull String name,
+                                            @NonNull String id,
+                                            boolean required,
+                                            @Nullable LocalDateTime max,
+                                            @Nullable LocalDateTime min,
+                                            @Nullable LocalDateTime value,
+                                            @Nullable Message label,
+                                            @NonNull List<Message> errors) implements FormElement, GlobalAttributes, FormElementAttributes {
 
     /**
      *

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/InputEmailFormElement.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/InputEmailFormElement.java
@@ -18,238 +18,42 @@ package io.micronaut.views.fields;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Input Email.
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email">Input Email</a>
+ * @param name Name of the form control. Submitted with the form as part of a name/value pair
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
+ * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
+ * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
+ * @param maxLength The maximum string length that the user can enter into the text input.
+ * @param minLength The minimum string length that the user can enter into the text input.
+ * @param pattern The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
+ * @param size The size attribute is a numeric value indicating how many characters wide the input field should be.
+ * @param value Input email value
+ * @param label the input label
+ * @param errors errors associated with this input
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = InputEmailFormElement.Builder.class))
-public class InputEmailFormElement implements FormElement, GlobalAttributes, FormElementAttributes {
-    @NonNull
-    private final String name;
-
-    @Nullable
-    private final String id;
-
-    /**
-     * The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    private final String placeholder;
-
-    private final boolean required;
-
-    private final boolean readOnly;
-
-    /**
-     * The maximum string length that the user can enter into the text input.
-     */
-    @Nullable
-    private final Integer maxLength;
-
-    /**
-     * The minimum string length that the user can enter into the text input.
-     */
-    @Nullable
-    private final Integer minLength;
-
-    /**
-     * The size attribute is a numeric value indicating how many characters wide the input field should be.
-     */
-    @Nullable
-    private final Integer size;
-
-    /**
-     * The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     */
-    @Nullable
-    private final String pattern;
-
-    @Nullable
-    private final String value;
-
-    @Nullable
-    private final Message label;
-
-    @NonNull
-    private final List<Message> errors;
-
-    /**
-     *
-     * @param name Name of the form control. Submitted with the form as part of a name/value pair
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
-     * @param maxLength The maximum string length that the user can enter into the text input.
-     * @param minLength The minimum string length that the user can enter into the text input.
-     * @param pattern The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     * @param size The size attribute is a numeric value indicating how many characters wide the input field should be.
-     * @param value Input email value
-     * @param label the input label
-     * @param errors errors associated with this input
-     */
-    public InputEmailFormElement(@NonNull String name,
-                                 @NonNull String id,
-                                 @Nullable String placeholder,
-                                 boolean required,
-                                 boolean readOnly,
-                                 @Nullable Integer maxLength,
-                                 @Nullable Integer minLength,
-                                 @Nullable String pattern,
-                                 @Nullable Integer size,
-                                 @Nullable String value,
-                                 @Nullable Message label,
-                                 @NonNull List<Message> errors) {
-        this.name = name;
-        this.id = id;
-        this.placeholder = placeholder;
-        this.required = required;
-        this.readOnly = readOnly;
-        this.maxLength = maxLength;
-        this.minLength = minLength;
-        this.pattern = pattern;
-        this.size = size;
-        this.value = value;
-        this.label = label;
-        this.errors = errors;
-    }
-
-    @Override
-    @NonNull
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    @Nullable
-    public String getId() {
-        return id;
-    }
-
-    /**
-     *
-     * @return The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    public String getPlaceholder() {
-        return placeholder;
-    }
-
-    /**
-     *
-     * @return A Boolean attribute which, if present, means this field cannot be edited by the user.
-     */
-    public boolean isReadOnly() {
-        return readOnly;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    /**
-     *
-     * @return The maximum string length that the user can enter into the text input.
-     */
-    @Nullable
-    public Integer getMaxLength() {
-        return maxLength;
-    }
-
-    /**
-     *
-     * @return The minimum string length that the user can enter into the text input.
-     */
-    @Nullable
-    public Integer getMinLength() {
-        return minLength;
-    }
-
-    /**
-     *
-     * @return The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     */
-    @Nullable
-    public String getPattern() {
-        return pattern;
-    }
-
-    /**
-     *
-     * @return The size attribute is a numeric value indicating how many characters wide the input field should be.
-     */
-    public Integer getSize() {
-        return size;
-    }
-
-    /**
-     *
-     * @return Input email value
-     */
-    @Nullable
-    public String getValue() {
-        return value;
-    }
-
-    @Override
-    @Nullable
-    public Message getLabel() {
-        return label;
-    }
-
-    @Override
-    @NonNull
-    public List<Message> getErrors() {
-        return errors;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof InputEmailFormElement that)) return false;
-
-        if (required != that.required) return false;
-        if (readOnly != that.readOnly) return false;
-        if (!Objects.equals(name, that.name)) return false;
-        if (!Objects.equals(id, that.id)) return false;
-        if (!Objects.equals(placeholder, that.placeholder))
-            return false;
-        if (!Objects.equals(maxLength, that.maxLength))
-            return false;
-        if (!Objects.equals(minLength, that.minLength))
-            return false;
-        if (!Objects.equals(size, that.size)) return false;
-        if (!Objects.equals(pattern, that.pattern)) return false;
-        if (!Objects.equals(value, that.value)) return false;
-        if (!Objects.equals(label, that.label)) return false;
-        return Objects.equals(errors, that.errors);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (placeholder != null ? placeholder.hashCode() : 0);
-        result = 31 * result + (required ? 1 : 0);
-        result = 31 * result + (readOnly ? 1 : 0);
-        result = 31 * result + (maxLength != null ? maxLength.hashCode() : 0);
-        result = 31 * result + (minLength != null ? minLength.hashCode() : 0);
-        result = 31 * result + (size != null ? size.hashCode() : 0);
-        result = 31 * result + (pattern != null ? pattern.hashCode() : 0);
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        result = 31 * result + (errors != null ? errors.hashCode() : 0);
-        return result;
-    }
+public record InputEmailFormElement(@NonNull String name,
+                                    @NonNull String id,
+                                    @Nullable String placeholder,
+                                    boolean required,
+                                    boolean readOnly,
+                                    @Nullable Integer maxLength,
+                                    @Nullable Integer minLength,
+                                    @Nullable String pattern,
+                                    @Nullable Integer size,
+                                    @Nullable String value,
+                                    @Nullable Message label,
+                                    @NonNull List<Message> errors) implements FormElement, GlobalAttributes, FormElementAttributes {
 
     /**
      *

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/InputNumberFormElement.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/InputNumberFormElement.java
@@ -21,220 +21,37 @@ import io.micronaut.core.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Input type Number.
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number">input number</a>
+ * @param name Name of the form control. Submitted with the form as part of a name/value pair
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param value A number representing the value of the input number.
+ * @param max The maximum value to accept for this input.
+ * @param min The minimum value to accept for this input.
+ * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
+ * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
+ * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
+ * @param step The step attribute is a number that specifies the granularity that the value must adhere to, or the special value any.
+ * @param label represents a caption for an item in a user interface
+ * @param errors errors associated with this input
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = InputNumberFormElement.Builder.class))
-public class InputNumberFormElement implements FormElement, GlobalAttributes, FormElementAttributes {
-    @NonNull
-    private final String name;
-
-    @Nullable
-    private final String id;
-
-    @Nullable
-    private final Number value;
-
-    /**
-     * The maximum value to accept for this input.
-     */
-    @Nullable
-    private final Number max;
-
-    /**
-     * The minimum value to accept for this input.
-     */
-    @Nullable
-    private final Number min;
-
-    /**
-     * The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    private final String placeholder;
-
-    private final boolean required;
-
-    /**
-     * A Boolean attribute which, if present, means this field cannot be edited by the user.
-     */
-    private final boolean readOnly;
-
-
-    /**
-     * The step attribute is a number that specifies the granularity that the value must adhere to, or the special value any.
-     */
-    @Nullable
-    private final String step;
-
-    @NonNull
-    private final Message label;
-
-    @NonNull
-    private final List<Message> errors;
-
-    /**
-     *
-     * @param name Name of the form control. Submitted with the form as part of a name/value pair
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param value A number representing the value of the input number.
-     * @param max The maximum value to accept for this input.
-     * @param min The minimum value to accept for this input.
-     * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
-     * @param step The step attribute is a number that specifies the granularity that the value must adhere to, or the special value any.
-     * @param label represents a caption for an item in a user interface
-     * @param errors errors associated with this input
-     */
-    public InputNumberFormElement(@NonNull String name,
-                                  @Nullable String id,
-                                  @Nullable Number value,
-                                  @Nullable Number max,
-                                  @Nullable Number min,
-                                  @Nullable String placeholder,
-                                  boolean required,
-                                  boolean readOnly,
-                                  @Nullable String step,
-                                  @NonNull Message label,
-                                  @NonNull List<Message> errors) {
-        this.name = name;
-        this.id = id;
-        this.value = value;
-        this.max = max;
-        this.min = min;
-        this.placeholder = placeholder;
-        this.required = required;
-        this.readOnly = readOnly;
-        this.step = step;
-        this.label = label;
-        this.errors = errors;
-    }
-
-    @Override
-    @NonNull
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    @Nullable
-    public String getId() {
-        return id;
-    }
-
-    /**
-     *
-     * @return A number representing the value of the input number
-     */
-    @Nullable
-    public Number getValue() {
-        return value;
-    }
-
-    /**
-     *
-     * @return The maximum value to accept for this input.
-     */
-    @Nullable
-    public Number getMax() {
-        return max;
-    }
-
-    /**
-     *
-     * @return The minimum value to accept for this input.
-     */
-    @Nullable
-    public Number getMin() {
-        return min;
-    }
-
-    /**
-     *
-     * @return The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    public String getPlaceholder() {
-        return placeholder;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    /**
-     *
-     * @return A Boolean attribute which, if present, means this field cannot be edited by the user.
-     */
-    public boolean isReadOnly() {
-        return readOnly;
-    }
-
-    /**
-     *
-     * @return The step attribute is a number that specifies the granularity that the value must adhere to, or the special value any.
-     */
-    @Nullable
-    public String getStep() {
-        return step;
-    }
-
-    @Override
-    @NonNull
-    public Message getLabel() {
-        return label;
-    }
-
-    @Override
-    @NonNull
-    public List<Message> getErrors() {
-        return this.errors;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof InputNumberFormElement that)) return false;
-
-        if (required != that.required) return false;
-        if (readOnly != that.readOnly) return false;
-        if (!Objects.equals(name, that.name)) return false;
-        if (!Objects.equals(id, that.id)) return false;
-        if (!Objects.equals(value, that.value)) return false;
-        if (!Objects.equals(max, that.max)) return false;
-        if (!Objects.equals(min, that.min)) return false;
-        if (!Objects.equals(placeholder, that.placeholder))
-            return false;
-        if (!Objects.equals(step, that.step)) return false;
-        if (!Objects.equals(label, that.label)) return false;
-        return Objects.equals(errors, that.errors);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (max != null ? max.hashCode() : 0);
-        result = 31 * result + (min != null ? min.hashCode() : 0);
-        result = 31 * result + (placeholder != null ? placeholder.hashCode() : 0);
-        result = 31 * result + (required ? 1 : 0);
-        result = 31 * result + (readOnly ? 1 : 0);
-        result = 31 * result + (step != null ? step.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        result = 31 * result + (errors != null ? errors.hashCode() : 0);
-        return result;
-    }
-
+public record InputNumberFormElement(@NonNull String name,
+                                     @Nullable String id,
+                                     @Nullable Number value,
+                                     @Nullable Number max,
+                                     @Nullable Number min,
+                                     @Nullable String placeholder,
+                                     boolean required,
+                                     boolean readOnly,
+                                     @Nullable String step,
+                                     @NonNull Message label,
+                                     @NonNull List<Message> errors) implements FormElement, GlobalAttributes, FormElementAttributes {
 
     /**
      *

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/InputPasswordFormElement.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/InputPasswordFormElement.java
@@ -21,242 +21,39 @@ import io.micronaut.core.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Input Password.
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password">Input Password</a>
+ * @param name Name of the form control. Submitted with the form as part of a name/value pair
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
+ * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
+ * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
+ * @param maxLength The maximum string length that the user can enter into the text input.
+ * @param minLength The minimum string length that the user can enter into the text input.
+ * @param pattern The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
+ * @param size The size attribute is a numeric value indicating how many characters wide the input field should be.
+ * @param value The value attribute of the input element
+ * @param label the input label
+ * @param errors errors associated with this input
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = InputPasswordFormElement.Builder.class))
-public class InputPasswordFormElement implements FormElement, FormElementAttributes, GlobalAttributes {
-    @NonNull
-    private final String name;
-
-    @Nullable
-    private final String id;
-
-    /**
-     * The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    private final String placeholder;
-
-    private final boolean required;
-
-    /**
-     * Whether the field cannot be edited by the use.
-     */
-    private final boolean readOnly;
-
-    /**
-     * The maximum string length that the user can enter into the password input.
-     */
-    @Nullable
-    private final Integer maxLength;
-
-    /**
-     * The minimum string length that the user can enter into the password input.
-     */
-    @Nullable
-    private final Integer minLength;
-
-    /**
-     * The size attribute is a numeric value indicating how many characters wide the input field should be.
-     */
-    @Nullable
-    private final Integer size;
-
-    /**
-     * The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     */
-    @Nullable
-    private final String pattern;
-
-    /**
-     * The value attribute of the input element.
-     */
-    @Nullable
-    private final String value;
-
-    @Nullable
-    private final Message label;
-
-    @NonNull
-    private final List<Message> errors;
-
-    /**
-     *
-     * @param name Name of the form control. Submitted with the form as part of a name/value pair
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
-     * @param maxLength The maximum string length that the user can enter into the text input.
-     * @param minLength The minimum string length that the user can enter into the text input.
-     * @param pattern The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     * @param size The size attribute is a numeric value indicating how many characters wide the input field should be.
-     * @param value The value attribute of the input element
-     * @param label the input label
-     * @param errors errors associated with this input
-     */
-    public InputPasswordFormElement(@NonNull String name,
-                                    @NonNull String id,
-                                    @Nullable String placeholder,
-                                    boolean required,
-                                    boolean readOnly,
-                                    @Nullable Integer maxLength,
-                                    @Nullable Integer minLength,
-                                    @Nullable String pattern,
-                                    @Nullable Integer size,
-                                    @Nullable String value,
-                                    @Nullable Message label,
-                                    @NonNull List<Message> errors) {
-        this.name = name;
-        this.id = id;
-        this.placeholder = placeholder;
-        this.required = required;
-        this.readOnly = readOnly;
-        this.maxLength = maxLength;
-        this.minLength = minLength;
-        this.pattern = pattern;
-        this.size = size;
-        this.value = value;
-        this.label = label;
-        this.errors = errors;
-    }
-
-    @Override
-    @NonNull
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    @Nullable
-    public String getId() {
-        return id;
-    }
-
-    /**
-     *
-     * @return The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    public String getPlaceholder() {
-        return placeholder;
-    }
-
-    /**
-     *
-     * @return A Boolean attribute which, if present, means this field cannot be edited by the user.
-     */
-    public boolean isReadOnly() {
-        return readOnly;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    /**
-     *
-     * @return The maximum string length that the user can enter into the text input.
-     */
-    @Nullable
-    public Integer getMaxLength() {
-        return maxLength;
-    }
-
-    /**
-     *
-     * @return The minimum string length that the user can enter into the text input.
-     */
-    @Nullable
-    public Integer getMinLength() {
-        return minLength;
-    }
-
-    /**
-     *
-     * @return The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     */
-    @Nullable
-    public String getPattern() {
-        return pattern;
-    }
-
-    /**
-     *
-     * @return The size attribute is a numeric value indicating how many characters wide the input field should be.
-     */
-    public Integer getSize() {
-        return size;
-    }
-
-    /**
-     *
-     * @return Input password value.
-     */
-    @Nullable
-    public String getValue() {
-        return value;
-    }
-
-    @Override
-    @Nullable
-    public Message getLabel() {
-        return label;
-    }
-
-    @Override
-    @NonNull
-    public List<Message> getErrors() {
-        return errors;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof InputPasswordFormElement that)) return false;
-
-        if (required != that.required) return false;
-        if (readOnly != that.readOnly) return false;
-        if (!Objects.equals(name, that.name)) return false;
-        if (!Objects.equals(id, that.id)) return false;
-        if (!Objects.equals(placeholder, that.placeholder))
-            return false;
-        if (!Objects.equals(maxLength, that.maxLength))
-            return false;
-        if (!Objects.equals(minLength, that.minLength))
-            return false;
-        if (!Objects.equals(size, that.size)) return false;
-        if (!Objects.equals(pattern, that.pattern)) return false;
-        if (!Objects.equals(value, that.value)) return false;
-        if (!Objects.equals(label, that.label)) return false;
-        return Objects.equals(errors, that.errors);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (placeholder != null ? placeholder.hashCode() : 0);
-        result = 31 * result + (required ? 1 : 0);
-        result = 31 * result + (readOnly ? 1 : 0);
-        result = 31 * result + (maxLength != null ? maxLength.hashCode() : 0);
-        result = 31 * result + (minLength != null ? minLength.hashCode() : 0);
-        result = 31 * result + (size != null ? size.hashCode() : 0);
-        result = 31 * result + (pattern != null ? pattern.hashCode() : 0);
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        result = 31 * result + (errors != null ? errors.hashCode() : 0);
-        return result;
-    }
+public record InputPasswordFormElement(@NonNull String name,
+                                       @NonNull String id,
+                                       @Nullable String placeholder,
+                                       boolean required,
+                                       boolean readOnly,
+                                       @Nullable Integer maxLength,
+                                       @Nullable Integer minLength,
+                                       @Nullable String pattern,
+                                       @Nullable Integer size,
+                                       @Nullable String value,
+                                       @Nullable Message label,
+                                       @NonNull List<Message> errors) implements FormElement, FormElementAttributes, GlobalAttributes {
 
     /**
      *

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/InputTelFormElement.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/InputTelFormElement.java
@@ -21,236 +21,39 @@ import io.micronaut.core.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Input Telephone.
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel">Input Tel</a>
+ * @param name Name of the form control. Submitted with the form as part of a name/value pair
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
+ * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
+ * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
+ * @param maxLength The maximum string length that the user can enter into the text input.
+ * @param minLength The minimum string length that the user can enter into the text input.
+ * @param pattern The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
+ * @param size The size attribute is a numeric value indicating how many characters wide the input field should be.
+ * @param value input tel value
+ * @param label the input label
+ * @param errors errors associated with this input
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = InputTelFormElement.Builder.class))
-public class InputTelFormElement implements FormElement, GlobalAttributes, FormElementAttributes {
-    @NonNull
-    private final String name;
-
-    @Nullable
-    private final String id;
-
-    /**
-     * The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    private final String placeholder;
-
-    private final boolean required;
-
-    private final boolean readOnly;
-
-    /**
-     * The maximum string length that the user can enter into the text input.
-     */
-    @Nullable
-    private final Integer maxLength;
-
-    /**
-     * The minimum string length that the user can enter into the text input.
-     */
-    @Nullable
-    private final Integer minLength;
-
-    /**
-     * The size attribute is a numeric value indicating how many characters wide the input field should be.
-     */
-    @Nullable
-    private final Integer size;
-
-    /**
-     * The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     */
-    @Nullable
-    private final String pattern;
-
-    @Nullable
-    private final String value;
-
-    @Nullable
-    private final Message label;
-
-    @NonNull
-    private final List<Message> errors;
-
-    /**
-     *
-     * @param name Name of the form control. Submitted with the form as part of a name/value pair
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
-     * @param maxLength The maximum string length that the user can enter into the text input.
-     * @param minLength The minimum string length that the user can enter into the text input.
-     * @param pattern The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     * @param size The size attribute is a numeric value indicating how many characters wide the input field should be.
-     * @param value input tel value
-     * @param label the input label
-     * @param errors errors associated with this input
-     */
-    public InputTelFormElement(@NonNull String name,
-                               @NonNull String id,
-                               @Nullable String placeholder,
-                               boolean required,
-                               boolean readOnly,
-                               @Nullable Integer maxLength,
-                               @Nullable Integer minLength,
-                               @Nullable String pattern,
-                               @Nullable Integer size,
-                               @Nullable String value,
-                               @Nullable Message label,
-                               @NonNull List<Message> errors) {
-        this.name = name;
-        this.id = id;
-        this.placeholder = placeholder;
-        this.required = required;
-        this.readOnly = readOnly;
-        this.maxLength = maxLength;
-        this.minLength = minLength;
-        this.pattern = pattern;
-        this.size = size;
-        this.value = value;
-        this.label = label;
-        this.errors = errors;
-    }
-
-    @Override
-    @NonNull
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    @Nullable
-    public String getId() {
-        return id;
-    }
-
-    /**
-     *
-     * @return The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    public String getPlaceholder() {
-        return placeholder;
-    }
-
-    /**
-     *
-     * @return A Boolean attribute which, if present, means this field cannot be edited by the user.
-     */
-    public boolean isReadOnly() {
-        return readOnly;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    /**
-     *
-     * @return The maximum string length that the user can enter into the text input.
-     */
-    @Nullable
-    public Integer getMaxLength() {
-        return maxLength;
-    }
-
-    /**
-     *
-     * @return The minimum string length that the user can enter into the text input.
-     */
-    @Nullable
-    public Integer getMinLength() {
-        return minLength;
-    }
-
-    /**
-     *
-     * @return The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     */
-    @Nullable
-    public String getPattern() {
-        return pattern;
-    }
-
-    /**
-     *
-     * @return The size attribute is a numeric value indicating how many characters wide the input field should be.
-     */
-    public Integer getSize() {
-        return size;
-    }
-
-    /**
-     *
-     * @return Input tel value.
-     */
-    @Nullable
-    public String getValue() {
-        return value;
-    }
-
-    @Override
-    @Nullable
-    public Message getLabel() {
-        return label;
-    }
-
-    @Override
-    @NonNull
-    public List<Message> getErrors() {
-        return errors;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof InputTelFormElement that)) return false;
-
-        if (required != that.required) return false;
-        if (readOnly != that.readOnly) return false;
-        if (!Objects.equals(name, that.name)) return false;
-        if (!Objects.equals(id, that.id)) return false;
-        if (!Objects.equals(placeholder, that.placeholder))
-            return false;
-        if (!Objects.equals(maxLength, that.maxLength))
-            return false;
-        if (!Objects.equals(minLength, that.minLength))
-            return false;
-        if (!Objects.equals(size, that.size)) return false;
-        if (!Objects.equals(pattern, that.pattern)) return false;
-        if (!Objects.equals(value, that.value)) return false;
-        if (!Objects.equals(label, that.label)) return false;
-        return Objects.equals(errors, that.errors);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (placeholder != null ? placeholder.hashCode() : 0);
-        result = 31 * result + (required ? 1 : 0);
-        result = 31 * result + (readOnly ? 1 : 0);
-        result = 31 * result + (maxLength != null ? maxLength.hashCode() : 0);
-        result = 31 * result + (minLength != null ? minLength.hashCode() : 0);
-        result = 31 * result + (size != null ? size.hashCode() : 0);
-        result = 31 * result + (pattern != null ? pattern.hashCode() : 0);
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        result = 31 * result + (errors != null ? errors.hashCode() : 0);
-        return result;
-    }
+public record InputTelFormElement(@NonNull String name,
+                                  @NonNull String id,
+                                  @Nullable String placeholder,
+                                  boolean required,
+                                  boolean readOnly,
+                                  @Nullable Integer maxLength,
+                                  @Nullable Integer minLength,
+                                  @Nullable String pattern,
+                                  @Nullable Integer size,
+                                  @Nullable String value,
+                                  @Nullable Message label,
+                                  @NonNull List<Message> errors) implements FormElement, GlobalAttributes, FormElementAttributes {
 
     /**
      *

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/InputTextFormElement.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/InputTextFormElement.java
@@ -18,238 +18,42 @@ package io.micronaut.views.fields;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Input Text.
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text">Input Text</a>
+ * @param name Name of the form control. Submitted with the form as part of a name/value pair
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
+ * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
+ * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
+ * @param maxLength The maximum string length that the user can enter into the text input.
+ * @param minLength The minimum string length that the user can enter into the text input.
+ * @param pattern The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
+ * @param size The size attribute is a numeric value indicating how many characters wide the input field should be.
+ * @param value input text value
+ * @param label the input label
+ * @param errors errors associated with this input
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = InputTextFormElement.Builder.class))
-public class InputTextFormElement implements FormElement, GlobalAttributes, FormElementAttributes {
-    @NonNull
-    private final String name;
-
-    @Nullable
-    private final String id;
-
-    /**
-     * The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    private final String placeholder;
-
-    private final boolean required;
-
-    private final boolean readOnly;
-
-    /**
-     * The maximum string length that the user can enter into the text input.
-     */
-    @Nullable
-    private final Integer maxLength;
-
-    /**
-     * The minimum string length that the user can enter into the text input.
-     */
-    @Nullable
-    private final Integer minLength;
-
-    /**
-     * The size attribute is a numeric value indicating how many characters wide the input field should be.
-     */
-    @Nullable
-    private final Integer size;
-
-    /**
-     * The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     */
-    @Nullable
-    private final String pattern;
-
-    @Nullable
-    private final String value;
-
-    @Nullable
-    private final Message label;
-
-    @NonNull
-    private final List<Message> errors;
-
-    /**
-     *
-     * @param name Name of the form control. Submitted with the form as part of a name/value pair
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
-     * @param maxLength The maximum string length that the user can enter into the text input.
-     * @param minLength The minimum string length that the user can enter into the text input.
-     * @param pattern The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     * @param size The size attribute is a numeric value indicating how many characters wide the input field should be.
-     * @param value input text value
-     * @param label the input label
-     * @param errors errors associated with this input
-     */
-    public InputTextFormElement(@NonNull String name,
-                                @NonNull String id,
-                                @Nullable String placeholder,
-                                boolean required,
-                                boolean readOnly,
-                                @Nullable Integer maxLength,
-                                @Nullable Integer minLength,
-                                @Nullable String pattern,
-                                @Nullable Integer size,
-                                @Nullable String value,
-                                @Nullable Message label,
-                                @NonNull List<Message> errors) {
-        this.name = name;
-        this.id = id;
-        this.placeholder = placeholder;
-        this.required = required;
-        this.readOnly = readOnly;
-        this.maxLength = maxLength;
-        this.minLength = minLength;
-        this.pattern = pattern;
-        this.size = size;
-        this.value = value;
-        this.label = label;
-        this.errors = errors;
-    }
-
-    @Override
-    @NonNull
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    @Nullable
-    public String getId() {
-        return id;
-    }
-
-    /**
-     *
-     * @return The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    public String getPlaceholder() {
-        return placeholder;
-    }
-
-    /**
-     *
-     * @return A Boolean attribute which, if present, means this field cannot be edited by the user.
-     */
-    public boolean isReadOnly() {
-        return readOnly;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    /**
-     *
-     * @return The maximum string length that the user can enter into the text input.
-     */
-    @Nullable
-    public Integer getMaxLength() {
-        return maxLength;
-    }
-
-    /**
-     *
-     * @return The minimum string length that the user can enter into the text input.
-     */
-    @Nullable
-    public Integer getMinLength() {
-        return minLength;
-    }
-
-    /**
-     *
-     * @return The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     */
-    @Nullable
-    public String getPattern() {
-        return pattern;
-    }
-
-    /**
-     *
-     * @return The size attribute is a numeric value indicating how many characters wide the input field should be.
-     */
-    public Integer getSize() {
-        return size;
-    }
-
-    /**
-     *
-     * @return Input text value
-     */
-    @Nullable
-    public String getValue() {
-        return value;
-    }
-
-    @Override
-    @Nullable
-    public Message getLabel() {
-        return label;
-    }
-
-    @Override
-    @NonNull
-    public List<Message> getErrors() {
-        return errors;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof InputTextFormElement that)) return false;
-
-        if (required != that.required) return false;
-        if (readOnly != that.readOnly) return false;
-        if (!Objects.equals(name, that.name)) return false;
-        if (!Objects.equals(id, that.id)) return false;
-        if (!Objects.equals(placeholder, that.placeholder))
-            return false;
-        if (!Objects.equals(maxLength, that.maxLength))
-            return false;
-        if (!Objects.equals(minLength, that.minLength))
-            return false;
-        if (!Objects.equals(size, that.size)) return false;
-        if (!Objects.equals(pattern, that.pattern)) return false;
-        if (!Objects.equals(value, that.value)) return false;
-        if (!Objects.equals(label, that.label)) return false;
-        return Objects.equals(errors, that.errors);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (placeholder != null ? placeholder.hashCode() : 0);
-        result = 31 * result + (required ? 1 : 0);
-        result = 31 * result + (readOnly ? 1 : 0);
-        result = 31 * result + (maxLength != null ? maxLength.hashCode() : 0);
-        result = 31 * result + (minLength != null ? minLength.hashCode() : 0);
-        result = 31 * result + (size != null ? size.hashCode() : 0);
-        result = 31 * result + (pattern != null ? pattern.hashCode() : 0);
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        result = 31 * result + (errors != null ? errors.hashCode() : 0);
-        return result;
-    }
+public record InputTextFormElement(@NonNull String name,
+                                   @NonNull String id,
+                                   @Nullable String placeholder,
+                                   boolean required,
+                                   boolean readOnly,
+                                   @Nullable Integer maxLength,
+                                   @Nullable Integer minLength,
+                                   @Nullable String pattern,
+                                   @Nullable Integer size,
+                                   @Nullable String value,
+                                   @Nullable Message label,
+                                   @NonNull List<Message> errors) implements FormElement, GlobalAttributes, FormElementAttributes {
 
     /**
      *

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/InputUrlFormElement.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/InputUrlFormElement.java
@@ -21,233 +21,35 @@ import io.micronaut.core.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text">Input Text</a>
+ * @param name Name of the form control. Submitted with the form as part of a name/value pair
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
+ * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
+ * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
+ * @param maxLength The maximum string length that the user can enter into the text input.
+ * @param minLength The minimum string length that the user can enter into the text input.
+ * @param pattern The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
+ * @param size The size attribute is a numeric value indicating how many characters wide the input field should be.
+ * @param value input url value
+ * @param label the input label
+ * @param errors errors associated with this input
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = InputUrlFormElement.Builder.class))
-public class InputUrlFormElement implements FormElement, GlobalAttributes, FormElementAttributes {
-    @NonNull
-    private final String name;
-
-    @Nullable
-    private final String id;
-
-    /**
-     * The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    private final String placeholder;
-
-    private final boolean required;
-
-    private final boolean readOnly;
-
-    /**
-     * The maximum string length that the user can enter into the text input.
-     */
-    @Nullable
-    private final Integer maxLength;
-
-    /**
-     * The minimum string length that the user can enter into the text input.
-     */
-    @Nullable
-    private final Integer minLength;
-
-    /**
-     * The size attribute is a numeric value indicating how many characters wide the input field should be.
-     */
-    @Nullable
-    private final Integer size;
-
-    /**
-     * The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     */
-    @Nullable
-    private final String pattern;
-
-    @Nullable
-    private final String value;
-
-    @Nullable
-    private final Message label;
-
-    @NonNull
-    private final List<Message> errors;
-
-    /**
-     *
-     * @param name Name of the form control. Submitted with the form as part of a name/value pair
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param placeholder The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     * @param readOnly A Boolean attribute which, if present, means this field cannot be edited by the user.
-     * @param maxLength The maximum string length that the user can enter into the text input.
-     * @param minLength The minimum string length that the user can enter into the text input.
-     * @param pattern The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     * @param size The size attribute is a numeric value indicating how many characters wide the input field should be.
-     * @param value input url value
-     * @param label the input label
-     * @param errors errors associated with this input
-     */
-    public InputUrlFormElement(@NonNull String name,
-                               @NonNull String id,
-                               @Nullable String placeholder,
-                               boolean required,
-                               boolean readOnly,
-                               @Nullable Integer maxLength,
-                               @Nullable Integer minLength,
-                               @Nullable String pattern,
-                               @Nullable Integer size,
-                               @Nullable String value,
-                               @Nullable Message label,
-                               @NonNull List<Message> errors) {
-        this.name = name;
-        this.id = id;
-        this.placeholder = placeholder;
-        this.required = required;
-        this.readOnly = readOnly;
-        this.maxLength = maxLength;
-        this.minLength = minLength;
-        this.pattern = pattern;
-        this.size = size;
-        this.value = value;
-        this.label = label;
-        this.errors = errors;
-    }
-
-    @Override
-    @NonNull
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    @Nullable
-    public String getId() {
-        return id;
-    }
-
-    /**
-     *
-     * @return The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    public String getPlaceholder() {
-        return placeholder;
-    }
-
-    /**
-     *
-     * @return A Boolean attribute which, if present, means this field cannot be edited by the user.
-     */
-    public boolean isReadOnly() {
-        return readOnly;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    /**
-     *
-     * @return The maximum string length that the user can enter into the text input.
-     */
-    @Nullable
-    public Integer getMaxLength() {
-        return maxLength;
-    }
-
-    /**
-     *
-     * @return The minimum string length that the user can enter into the text input.
-     */
-    @Nullable
-    public Integer getMinLength() {
-        return minLength;
-    }
-
-    /**
-     *
-     * @return The pattern attribute, when specified, is a regular expression that the input's value must match for the value to pass constraint validation.
-     */
-    @Nullable
-    public String getPattern() {
-        return pattern;
-    }
-
-    /**
-     *
-     * @return The size attribute is a numeric value indicating how many characters wide the input field should be.
-     */
-    public Integer getSize() {
-        return size;
-    }
-
-    /**
-     *
-     * @return Input url value.
-     */
-    @Nullable
-    public String getValue() {
-        return value;
-    }
-
-    @Override
-    @Nullable
-    public Message getLabel() {
-        return label;
-    }
-
-    @Override
-    @NonNull
-    public List<Message> getErrors() {
-        return errors;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof InputUrlFormElement that)) return false;
-
-        if (required != that.required) return false;
-        if (readOnly != that.readOnly) return false;
-        if (!Objects.equals(name, that.name)) return false;
-        if (!Objects.equals(id, that.id)) return false;
-        if (!Objects.equals(placeholder, that.placeholder))
-            return false;
-        if (!Objects.equals(maxLength, that.maxLength))
-            return false;
-        if (!Objects.equals(minLength, that.minLength))
-            return false;
-        if (!Objects.equals(size, that.size)) return false;
-        if (!Objects.equals(pattern, that.pattern)) return false;
-        if (!Objects.equals(value, that.value)) return false;
-        if (!Objects.equals(label, that.label)) return false;
-        return Objects.equals(errors, that.errors);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (placeholder != null ? placeholder.hashCode() : 0);
-        result = 31 * result + (required ? 1 : 0);
-        result = 31 * result + (readOnly ? 1 : 0);
-        result = 31 * result + (maxLength != null ? maxLength.hashCode() : 0);
-        result = 31 * result + (minLength != null ? minLength.hashCode() : 0);
-        result = 31 * result + (size != null ? size.hashCode() : 0);
-        result = 31 * result + (pattern != null ? pattern.hashCode() : 0);
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        result = 31 * result + (errors != null ? errors.hashCode() : 0);
-        return result;
-    }
+public record InputUrlFormElement(@NonNull String name,
+                                  @NonNull String id,
+                                  @Nullable String placeholder,
+                                  boolean required,
+                                  boolean readOnly,
+                                  @Nullable Integer maxLength,
+                                  @Nullable Integer minLength,
+                                  @Nullable String pattern,
+                                  @Nullable Integer size,
+                                  @Nullable String value,
+                                  @Nullable Message label,
+                                  @NonNull List<Message> errors) implements FormElement, GlobalAttributes, FormElementAttributes {
 
     /**
      *

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/Message.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/Message.java
@@ -29,14 +29,14 @@ public interface Message {
      * @return The i18n code which can be used to fetch a localized message.
      */
     @Nullable
-    String getCode();
+    String code();
 
     /**
      *
      * @return The default message to use if no code is specified or no localized message found
      */
     @NonNull
-    String getDefaultMessage();
+    String defaultMessage();
 
     /**
      *

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/Option.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/Option.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.views.fields;
 
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 
 import java.util.Objects;
@@ -25,6 +26,7 @@ import java.util.Objects;
  * @author Sergio del Amo
  * @since 4.1.0
  */
+@Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = Option.Builder.class))
 public class Option implements FormElement {
 
     private final boolean disabled;

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/Radio.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/Radio.java
@@ -19,44 +19,19 @@ import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 
-import java.util.Objects;
-
 /**
  * A Radio Form Element.
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio">Input Radio</a>
+ * @param value the value of the input radio element
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param label represents a caption for an item in a user interface
+ * @param checked whether the radio button is checked
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = Radio.Builder.class))
-public class Radio implements FormElement {
-    @NonNull
-    private final String value;
-
-    @NonNull
-    private final String id;
-
-    @NonNull
-    private final Message label;
-
-    @NonNull
-    private final boolean checked;
-
-    /**
-     *
-     * @param value the value of the input radio element
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param label represents a caption for an item in a user interface
-     * @param checked whether the radio button is checked
-     */
-    public Radio(String value,
-                 String id,
-                 Message label,
-                 boolean checked) {
-        this.value = value;
-        this.id = id;
-        this.label = label;
-        this.checked = checked;
-    }
+public record Radio(@NonNull String value, @NonNull String id, @NonNull Message label, @NonNull boolean checked) implements FormElement {
 
     /**
      *
@@ -91,28 +66,6 @@ public class Radio implements FormElement {
     @NonNull
     public Message getLabel() {
         return label;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Radio radio)) return false;
-
-        if (checked != radio.checked) return false;
-        if (!Objects.equals(value, radio.value)) return false;
-        if (!Objects.equals(id, radio.id)) return false;
-        return Objects.equals(label, radio.label);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = value != null ? value.hashCode() : 0;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        result = 31 * result + (checked ? 1 : 0);
-        return result;
     }
 
     /**

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/SelectFormElement.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/SelectFormElement.java
@@ -26,109 +26,17 @@ import java.util.Objects;
 /**
  * HTML Select.
  * <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select">Select</a>
+ * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
+ * @param name Name of the form control. Submitted with the form as part of a name/value pair
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param options Select Options
+ * @param label represents a caption for an item in a user interface
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = SelectFormElement.Builder.class))
-public class SelectFormElement implements FormElement, GlobalAttributes {
-    private final boolean required;
-    @NonNull
-    private final String name;
-
-    @Nullable
-    private final String id;
-
-    @NonNull
-    private final List<Option> options;
-
-    @NonNull
-    private final Message label;
-
-    /**
-     *
-     * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     * @param name Name of the form control. Submitted with the form as part of a name/value pair
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param options Select Options
-     * @param label represents a caption for an item in a user interface
-     */
-    public SelectFormElement(boolean required,
-                             @NonNull String name,
-                             @Nullable String id,
-                             @NonNull List<Option> options,
-                             Message label) {
-        this.required = required;
-        this.name = name;
-        this.id = id;
-        this.options = options;
-        this.label = label;
-    }
-
-    @Override
-    public boolean isRequired() {
-        return required;
-    }
-
-    /**
-     *
-     * @return represents a caption for an item in a user interface
-     */
-    @NonNull
-    public Message getLabel() {
-        return label;
-    }
-
-    /**
-     *
-     * @return The name of the control.
-     */
-    @NonNull
-    public String getName() {
-        return this.name;
-    }
-
-    /**
-     *
-     * @return An id attribute. Often used to allow the form element to be associated with a label element for accessibility purposes.
-     */
-    @Override
-    @Nullable
-    public String getId() {
-        return this.id;
-    }
-
-    /**
-     *
-     * @return Select Options
-     */
-    @NonNull
-    public List<Option> getOptions() {
-        return options;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SelectFormElement that)) return false;
-
-        if (required != that.required) return false;
-        if (!Objects.equals(name, that.name)) return false;
-        if (!Objects.equals(id, that.id)) return false;
-        if (!Objects.equals(options, that.options)) return false;
-        return Objects.equals(label, that.label);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = (required ? 1 : 0);
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (options != null ? options.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        return result;
-    }
+public record SelectFormElement(@NonNull boolean required, @NonNull String name, @Nullable String id, @NonNull List<Option> options, @NonNull Message label) implements FormElement, GlobalAttributes {
 
     /**
      *
@@ -138,7 +46,6 @@ public class SelectFormElement implements FormElement, GlobalAttributes {
     public static Builder builder() {
         return new Builder();
     }
-
 
     /**
      * Select Builder.

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/SimpleMessage.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/SimpleMessage.java
@@ -23,28 +23,14 @@ import java.util.Objects;
 
 /**
  * Simple implementation of {@link Message}.
+ * @param defaultMessage The default message to use if no code is specified or no localized message found.
+ * @param code The i18n code which can be used to fetch a localized message.
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected
-public class SimpleMessage implements Message {
-
-    @Nullable
-    private final String code;
-
-    @NonNull
-    private final String defaultMessage;
-
-    /**
-     *
-     * @param defaultMessage The default message to use if no code is specified or no localized message found.
-     * @param code The i18n code which can be used to fetch a localized message.
-     */
-    public SimpleMessage(@NonNull String defaultMessage,
-                         @Nullable String code) {
-        this.defaultMessage = defaultMessage;
-        this.code = code;
-    }
+public record SimpleMessage(@NonNull String defaultMessage, @Nullable String code) implements Message {
 
     @SuppressWarnings("NeedBraces")
     @Override
@@ -52,27 +38,14 @@ public class SimpleMessage implements Message {
         if (this == o) return true;
         if (!(o instanceof Message that)) return false;
 
-        if (!Objects.equals(code, that.getCode())) return false;
-        return Objects.equals(defaultMessage, that.getDefaultMessage());
+        if (!Objects.equals(code, that.code())) return false;
+        return Objects.equals(defaultMessage, that.defaultMessage());
     }
 
-    @SuppressWarnings("NeedBraces")
     @Override
     public int hashCode() {
         int result = code != null ? code.hashCode() : 0;
         result = 31 * result + (defaultMessage != null ? defaultMessage.hashCode() : 0);
         return result;
-    }
-
-    @Override
-    @Nullable
-    public String getCode() {
-        return code;
-    }
-
-    @Override
-    @NonNull
-    public String getDefaultMessage() {
-        return defaultMessage;
     }
 }

--- a/views-fieldset/src/main/java/io/micronaut/views/fields/TextareaFormElement.java
+++ b/views-fieldset/src/main/java/io/micronaut/views/fields/TextareaFormElement.java
@@ -21,192 +21,36 @@ import io.micronaut.core.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Text Area.
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea">Textarea</a>
+ * @param name Name of the form control. Submitted with the form as part of a name/value pair
+ * @param id It defines an identifier (ID) which must be unique in the whole document
+ * @param cols The visible width of the text control, in average character widths
+ * @param rows The number of visible text lines for the control.
+ * @param placeholder A hint to the user of what can be entered in the control
+ * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
+ * @param readOnly indicates that the user cannot modify the value of the control
+ * @param value text area content
+ * @param label represents a caption for an item in a user interface
+ * @param errors Form element validation Errors.
+ *
  * @author Sergio del Amo
  * @since 4.1.0
  */
 @Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = TextareaFormElement.Builder.class))
-public class TextareaFormElement implements FormElement, FormElementAttributes, GlobalAttributes {
-    @NonNull
-    private final String name;
+public record TextareaFormElement(@NonNull String name,
+                                  @NonNull String id,
+                                  @Nullable Integer cols,
+                                  @Nullable Integer rows,
+                                  @Nullable String placeholder,
+                                  boolean required,
+                                  boolean readOnly,
+                                  @Nullable String value,
+                                  @Nullable Message label,
+                                  @NonNull List<Message> errors) implements FormElement, FormElementAttributes, GlobalAttributes {
 
-    @Nullable
-    private final String id;
-
-    @Nullable
-    private final Integer cols;
-
-    @Nullable
-    private final Integer rows;
-
-    /**
-     * The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    private final String placeholder;
-
-    private final boolean required;
-
-    private final boolean readOnly;
-
-    @Nullable
-    private final String value;
-
-    @Nullable
-    private final Message label;
-
-    @NonNull
-    private final List<Message> errors;
-
-    /**
-     *
-     * @param name Name of the form control. Submitted with the form as part of a name/value pair
-     * @param id It defines an identifier (ID) which must be unique in the whole document
-     * @param cols The visible width of the text control, in average character widths
-     * @param rows The number of visible text lines for the control.
-     * @param placeholder A hint to the user of what can be entered in the control
-     * @param required If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     * @param readOnly indicates that the user cannot modify the value of the control
-     * @param value text area content
-     * @param label represents a caption for an item in a user interface
-     * @param errors Form element validation Errors.
-     */
-    public TextareaFormElement(@NonNull String name,
-                               @NonNull String id,
-                               @Nullable Integer cols,
-                               @Nullable Integer rows,
-                               @Nullable String placeholder,
-                               boolean required,
-                               boolean readOnly,
-                               @Nullable String value,
-                               @Nullable Message label,
-                               @NonNull List<Message> errors) {
-        this.name = name;
-        this.id = id;
-        this.cols = cols;
-        this.rows = rows;
-        this.placeholder = placeholder;
-        this.required = required;
-        this.readOnly = readOnly;
-        this.value = value;
-        this.label = label;
-        this.errors = errors;
-    }
-
-    @Override
-    @NonNull
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    @Nullable
-    public String getId() {
-        return id;
-    }
-
-    /**
-     *
-     * @return The placeholder attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field.
-     */
-    @Nullable
-    public String getPlaceholder() {
-        return placeholder;
-    }
-
-    /**
-     *
-     * @return A Boolean attribute which, if present, means this field cannot be edited by the user.
-     */
-    public boolean isReadOnly() {
-        return readOnly;
-    }
-
-    /**
-     *
-     * @return If true indicates that the user must specify a value for the input before the owning form can be submitted.
-     */
-    public boolean isRequired() {
-        return required;
-    }
-
-    /**
-     *
-     * @return The visible width of the text control, in average character widths
-     */
-    @Nullable
-    public Integer getCols() {
-        return cols;
-    }
-
-    /**
-     *
-     * @return The number of visible text lines for the control.
-     */
-    @Nullable
-    public Integer getRows() {
-        return rows;
-    }
-
-    /**
-     *
-     * @return text area content
-     */
-    @Nullable
-    public String getValue() {
-        return value;
-    }
-
-    @Override
-    @Nullable
-    public Message getLabel() {
-        return label;
-    }
-
-    @Override
-    @NonNull
-    public List<Message> getErrors() {
-        return errors;
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof TextareaFormElement that)) return false;
-
-        if (required != that.required) return false;
-        if (readOnly != that.readOnly) return false;
-        if (!Objects.equals(name, that.name)) return false;
-        if (!Objects.equals(id, that.id)) return false;
-        if (!Objects.equals(cols, that.cols)) return false;
-        if (!Objects.equals(rows, that.rows)) return false;
-        if (!Objects.equals(placeholder, that.placeholder))
-            return false;
-        if (!Objects.equals(value, that.value)) return false;
-        if (!Objects.equals(label, that.label)) return false;
-        return Objects.equals(errors, that.errors);
-    }
-
-    @SuppressWarnings("NeedBraces")
-    @Override
-    public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (cols != null ? cols.hashCode() : 0);
-        result = 31 * result + (rows != null ? rows.hashCode() : 0);
-        result = 31 * result + (placeholder != null ? placeholder.hashCode() : 0);
-        result = 31 * result + (required ? 1 : 0);
-        result = 31 * result + (readOnly ? 1 : 0);
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (label != null ? label.hashCode() : 0);
-        result = 31 * result + (errors != null ? errors.hashCode() : 0);
-        return result;
-    }
 
     /**
      *

--- a/views-fieldset/src/test/java/io/micronaut/views/fields/ConstraintViolationMessageTest.java
+++ b/views-fieldset/src/test/java/io/micronaut/views/fields/ConstraintViolationMessageTest.java
@@ -35,8 +35,8 @@ class ConstraintViolationMessageTest {
         assertEquals(1, ex.getConstraintViolations().size());
         ConstraintViolation<?> violation = ex.getConstraintViolations().iterator().next();
         Message message = new ConstraintViolationMessage(violation);
-        assertEquals("must be a well-formed email address", message.getDefaultMessage());
-        assertEquals("contact.email.email", message.getCode());
+        assertEquals("must be a well-formed email address", message.defaultMessage());
+        assertEquals("contact.email.email", message.code());
 
     }
 

--- a/views-fieldset/src/test/java/io/micronaut/views/fields/InputDataTimeLocalFormElementTest.java
+++ b/views-fieldset/src/test/java/io/micronaut/views/fields/InputDataTimeLocalFormElementTest.java
@@ -26,12 +26,12 @@ class InputDataTimeLocalFormElementTest {
             .build();
 
         assertNotNull(formElement);
-        assertEquals(id, formElement.getId());
-        assertFalse(formElement.isRequired());
-        assertEquals(name, formElement.getName());
-        assertEquals("2018-06-12T19:30", formElement.getValue().toString());
-        assertEquals("2018-06-07T00:00", formElement.getMin().toString());
-        assertEquals("2018-06-14T00:00", formElement.getMax().toString());
+        assertEquals(id, formElement.id());
+        assertFalse(formElement.required());
+        assertEquals(name, formElement.name());
+        assertEquals("2018-06-12T19:30", formElement.value().toString());
+        assertEquals("2018-06-07T00:00", formElement.min().toString());
+        assertEquals("2018-06-14T00:00", formElement.max().toString());
     }
 
 }

--- a/views-fieldset/src/test/java/io/micronaut/views/fields/InputDateFormElementTest.java
+++ b/views-fieldset/src/test/java/io/micronaut/views/fields/InputDateFormElementTest.java
@@ -24,11 +24,11 @@ class InputDateFormElementTest {
             .max(max)
             .build();
         assertNotNull(formElement);
-        assertEquals(id, formElement.getId());
-        assertEquals(name, formElement.getName());
-        assertEquals(value, formElement.getValue());
-        assertEquals(min, formElement.getMin());
-        assertEquals(max, formElement.getMax());
+        assertEquals(id, formElement.id());
+        assertEquals(name, formElement.name());
+        assertEquals(value, formElement.value());
+        assertEquals(min, formElement.min());
+        assertEquals(max, formElement.max());
 
         BeanIntrospection<InputDateFormElement> introspection = BeanIntrospection.getIntrospection(InputDateFormElement.class);
         BeanIntrospection.Builder<InputDateFormElement> builder = introspection.builder();
@@ -40,10 +40,10 @@ class InputDateFormElementTest {
             .with("max", max)
             .build();
         assertNotNull(formElement);
-        assertEquals(id, formElement.getId());
-        assertEquals(name, formElement.getName());
-        assertEquals(value, formElement.getValue());
-        assertEquals(min, formElement.getMin());
-        assertEquals(max, formElement.getMax());
+        assertEquals(id, formElement.id());
+        assertEquals(name, formElement.name());
+        assertEquals(value, formElement.value());
+        assertEquals(min, formElement.min());
+        assertEquals(max, formElement.max());
     }
 }

--- a/views-fieldset/src/test/java/io/micronaut/views/fields/InputNumberFormElementTest.java
+++ b/views-fieldset/src/test/java/io/micronaut/views/fields/InputNumberFormElementTest.java
@@ -46,14 +46,14 @@ class InputNumberFormElementTest {
 
     private void assertFormElement(InputNumberFormElement formElement) {
         assertNotNull(formElement);
-        assertEquals(ID, formElement.getId());
-        assertEquals(NAME, formElement.getName());
-        assertEquals(REQUIRED, formElement.isRequired());
-        assertEquals(READONLY, formElement.isReadOnly());
-        assertEquals(PLACEHOLDER, formElement.getPlaceholder());
-        assertEquals(MIN, formElement.getMin());
-        assertEquals(MAX, formElement.getMax());
-        assertEquals(STEP, formElement.getStep());
+        assertEquals(ID, formElement.id());
+        assertEquals(NAME, formElement.name());
+        assertEquals(REQUIRED, formElement.required());
+        assertEquals(READONLY, formElement.readOnly());
+        assertEquals(PLACEHOLDER, formElement.placeholder());
+        assertEquals(MIN, formElement.min());
+        assertEquals(MAX, formElement.max());
+        assertEquals(STEP, formElement.step());
     }
 
 }

--- a/views-fieldset/src/test/java/io/micronaut/views/fields/InputPasswordFormElementTest.java
+++ b/views-fieldset/src/test/java/io/micronaut/views/fields/InputPasswordFormElementTest.java
@@ -46,13 +46,13 @@ class InputPasswordFormElementTest {
 
     private void assertFormElement(InputPasswordFormElement formElement) {
         assertNotNull(formElement);
-        assertEquals(ID, formElement.getId());
-        assertEquals(NAME, formElement.getName());
-        assertEquals(REQUIRED, formElement.isRequired());
-        assertEquals(READONLY, formElement.isReadOnly());
-        assertEquals(SIZE, formElement.getSize());
-        assertEquals(PLACEHOLDER, formElement.getPlaceholder());
-        assertEquals(MINLENGTH, formElement.getMinLength());
-        assertEquals(MAXLENGTH, formElement.getMaxLength());
+        assertEquals(ID, formElement.id());
+        assertEquals(NAME, formElement.name());
+        assertEquals(REQUIRED, formElement.required());
+        assertEquals(READONLY, formElement.readOnly());
+        assertEquals(SIZE, formElement.size());
+        assertEquals(PLACEHOLDER, formElement.placeholder());
+        assertEquals(MINLENGTH, formElement.minLength());
+        assertEquals(MAXLENGTH, formElement.maxLength());
     }
 }

--- a/views-fieldset/src/test/java/io/micronaut/views/fields/InputTextFormElementTest.java
+++ b/views-fieldset/src/test/java/io/micronaut/views/fields/InputTextFormElementTest.java
@@ -45,17 +45,14 @@ class InputTextFormElementTest {
 
     private void assertFormElement(InputTextFormElement formElement) {
         assertNotNull(formElement);
-        assertEquals(ID, formElement.getId());
-        assertEquals(NAME, formElement.getName());
-        assertEquals(REQUIRED, formElement.isRequired());
-        assertEquals(READONLY, formElement.isReadOnly());
-        assertEquals(SIZE, formElement.getSize());
-        assertEquals(PLACEHOLDER, formElement.getPlaceholder());
-        assertEquals(MINLENGTH, formElement.getMinLength());
-        assertEquals(MAXLENGTH, formElement.getMaxLength());
-
-
-
+        assertEquals(ID, formElement.id());
+        assertEquals(NAME, formElement.name());
+        assertEquals(REQUIRED, formElement.required());
+        assertEquals(READONLY, formElement.readOnly());
+        assertEquals(SIZE, formElement.size());
+        assertEquals(PLACEHOLDER, formElement.placeholder());
+        assertEquals(MINLENGTH, formElement.minLength());
+        assertEquals(MAXLENGTH, formElement.maxLength());
     }
 
 }

--- a/views-fieldset/src/test/java/io/micronaut/views/fields/OptionTest.java
+++ b/views-fieldset/src/test/java/io/micronaut/views/fields/OptionTest.java
@@ -9,9 +9,20 @@ class OptionTest {
     @Test
     void builder() {
         Option option = Option.builder().value("MUSIC").label(new SimpleMessage( "Music", "genre.music")).build();
+
         assertNotNull(option);
         assertEquals("MUSIC", option.getValue());
-        assertEquals("genre.music", option.getLabel().getCode());
-        assertEquals("Music", option.getLabel().getDefaultMessage());
+        assertEquals("genre.music", option.getLabel().code());
+        assertEquals("Music", option.getLabel().defaultMessage());
+
+        BeanIntrospection<Option> introspection = BeanIntrospection.getIntrospection(Option.class);
+        BeanIntrospection.Builder<Option> builder = introspection.builder();
+        option = builder
+            .with("value", "MUSIC")
+            .with("label", new SimpleMessage( "Music", "genre.music"))
+            .build();
+
+        assertEquals("MUSIC", option.getValue());
+        assertEquals("Music", option.getLabel().defaultMessage());
     }
 }

--- a/views-fieldset/src/test/java/io/micronaut/views/fields/SelectFormElementTest.java
+++ b/views-fieldset/src/test/java/io/micronaut/views/fields/SelectFormElementTest.java
@@ -42,9 +42,9 @@ class SelectFormElementTest {
                                          List<Option> options,
                                          SelectFormElement selectFormElement) {
         assertNotNull(selectFormElement);
-        assertEquals(name, selectFormElement.getName());
-        assertEquals(id, selectFormElement.getId());
-        assertNotNull(selectFormElement.getOptions());
-        assertEquals(4, selectFormElement.getOptions().size());
+        assertEquals(name, selectFormElement.name());
+        assertEquals(id, selectFormElement.id());
+        assertNotNull(selectFormElement.options());
+        assertEquals(4, selectFormElement.options().size());
     }
 }

--- a/views-fieldset/src/test/java/io/micronaut/views/fields/TextAreaFormElementTest.java
+++ b/views-fieldset/src/test/java/io/micronaut/views/fields/TextAreaFormElementTest.java
@@ -43,10 +43,10 @@ class TextAreaFormElementTest {
                                            String content,
                                            TextareaFormElement formElement) {
         assertNotNull(formElement);
-        assertEquals(name, formElement.getName());
-        assertEquals(id, formElement.getId());
-        assertEquals(rows, formElement.getRows());
-        assertEquals(cols, formElement.getCols());
-        assertEquals(content, formElement.getValue());
+        assertEquals(name, formElement.name());
+        assertEquals(id, formElement.id());
+        assertEquals(rows, formElement.rows());
+        assertEquals(cols, formElement.cols());
+        assertEquals(content, formElement.value());
     }
 }


### PR DESCRIPTION
We could use records instead of objects

Had to leave the equals and hashcode for the Message subtypes as they compare themselves with Message instances (they don't need to be the same subtype in the tests)