### PR TITLE
Add ability to render thymeleaf fragments

### DIFF
--- a/views-thymeleaf/src/main/java/io/micronaut/views/thymeleaf/ThymeleafViewsRenderer.java
+++ b/views-thymeleaf/src/main/java/io/micronaut/views/thymeleaf/ThymeleafViewsRenderer.java
@@ -116,7 +116,9 @@ public class ThymeleafViewsRenderer<T> implements ViewsRenderer<T, HttpRequest<?
      * @param viewName The view name
      * @param context The context
      * @param writer The writer
+     * @deprecated Use {@link #render(String, Set, IContext, Writer)} instead.
      */
+    @Deprecated(forRemoval = true, since = "5.2.0")
     public void render(String viewName, IContext context, Writer writer) {
         try {
             engine.process(viewName, context, writer);

--- a/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderFragment.groovy
+++ b/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderFragment.groovy
@@ -36,18 +36,12 @@ class ThymeleafViewRenderFragment extends Specification {
     }
 
     void "exists is successful when using fragments"() {
-        when:
-        var result = viewRenderer.exists("fragment :: thefragment")
-
-        then:
-        result
+        expect:
+        viewRenderer.exists("fragment :: thefragment")
     }
 
     void "exists is successful when using regular view name"() {
-        when:
-        var result = viewRenderer.exists("fragment")
-
-        then:
-        result
+        expect:
+        viewRenderer.exists("fragment")
     }
 }

--- a/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderFragment.groovy
+++ b/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderFragment.groovy
@@ -34,4 +34,20 @@ class ThymeleafViewRenderFragment extends Specification {
         then:
         result.contains("MAIN") && result.contains("FRAGMENT")
     }
+
+    void "exists is successful when using fragments"() {
+        when:
+        var result = viewRenderer.exists("fragment :: thefragment")
+
+        then:
+        result
+    }
+
+    void "exists is successful when using regular view name"() {
+        when:
+        var result = viewRenderer.exists("fragment")
+
+        then:
+        result
+    }
 }

--- a/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderFragment.groovy
+++ b/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderFragment.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.views.thymeleaf
+
+import io.micronaut.core.io.Writable
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class ThymeleafViewRenderFragment extends Specification {
+
+    @Inject
+    ThymeleafViewsRenderer<?> viewRenderer
+
+    void "can render fragment"() {
+        when:
+        Writable writeable = viewRenderer.render("fragment :: thefragment", ["some": "data"], null)
+        String result = new StringWriter().with {
+            writeable.writeTo(it)
+            it.toString()
+        }
+
+        then:
+        result == "<div>FRAGMENT</div>"
+    }
+
+    void "can render main body"() {
+        when:
+        Writable writeable = viewRenderer.render("fragment", ["some": "data"], null)
+        String result = new StringWriter().with {
+            writeable.writeTo(it)
+            it.toString()
+        }
+
+        then:
+        result.contains("MAIN") && result.contains("FRAGMENT")
+    }
+}

--- a/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderFragmentSpec.groovy
+++ b/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderFragmentSpec.groovy
@@ -1,35 +1,28 @@
 package io.micronaut.views.thymeleaf
 
-import io.micronaut.core.io.Writable
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification
 
+import static io.micronaut.views.thymeleaf.WriteableUtils.*
+
 @MicronautTest(startApplication = false)
-class ThymeleafViewRenderFragment extends Specification {
+class ThymeleafViewRenderFragmentSpec extends Specification {
 
     @Inject
     ThymeleafViewsRenderer<?> viewRenderer
 
     void "can render fragment"() {
-        when:
-        Writable writeable = viewRenderer.render("fragment :: thefragment", ["some": "data"], null)
-        String result = new StringWriter().with {
-            writeable.writeTo(it)
-            it.toString()
-        }
+        expect:
+        "<div>FRAGMENT</div>" == writableToString(viewRenderer.render("fragment :: thefragment", ["some": "data"], null))
 
-        then:
-        result == "<div>FRAGMENT</div>"
+        and:
+        "<div>FRAGMENT 2</div>" == writableToString(viewRenderer.render("fragment :: thefragment2", ["some": "data"], null))
     }
 
     void "can render main body"() {
         when:
-        Writable writeable = viewRenderer.render("fragment", ["some": "data"], null)
-        String result = new StringWriter().with {
-            writeable.writeTo(it)
-            it.toString()
-        }
+        String result = writableToString(viewRenderer.render("fragment", ["some": "data"], null))
 
         then:
         result.contains("MAIN") && result.contains("FRAGMENT")

--- a/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderNullableRequestSpec.groovy
+++ b/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/ThymeleafViewRenderNullableRequestSpec.groovy
@@ -13,11 +13,7 @@ class ThymeleafViewRenderNullableRequestSpec extends Specification {
 
     void "views can be render with no request"() {
         when:
-        Writable writeable = viewRenderer.render("tim", ["username": "Tim"], null)
-        String result = new StringWriter().with {
-            writeable.writeTo(it)
-            it.toString()
-        }
+        String result = WriteableUtils.writableToString(viewRenderer.render("tim", ["username": "Tim"], null))
 
         then:
         result.contains("username: <span>Tim</span>")

--- a/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/WriteableUtils.groovy
+++ b/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/WriteableUtils.groovy
@@ -1,0 +1,4 @@
+package io.micronaut.views.thymeleaf
+
+class WriteableUtils {
+}

--- a/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/WriteableUtils.groovy
+++ b/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/WriteableUtils.groovy
@@ -1,4 +1,16 @@
 package io.micronaut.views.thymeleaf
 
-class WriteableUtils {
+import io.micronaut.core.io.Writable
+
+final class WriteableUtils {
+    private WriteableUtils() {
+
+    }
+
+    static String writableToString(Writable writable) {
+         return new StringWriter().with {
+            writable.writeTo(it)
+            it.toString()
+        }
+    }
 }

--- a/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/web/LinkTestController.groovy
+++ b/views-thymeleaf/src/test/groovy/io/micronaut/views/thymeleaf/web/LinkTestController.groovy
@@ -12,7 +12,7 @@ import io.micronaut.views.View
 class LinkTestController {
     @Get
     @View("contextRelativeUrl")
-    public HttpResponse contextRelativeUrl() {
+    HttpResponse contextRelativeUrl() {
         return HttpResponse.ok()
     }
 

--- a/views-thymeleaf/src/test/resources/views/fragment.html
+++ b/views-thymeleaf/src/test/resources/views/fragment.html
@@ -6,5 +6,6 @@
 <body>
 <div>MAIN</div>
 <div th:fragment="thefragment">FRAGMENT</div>
+<div th:fragment="thefragment2">FRAGMENT 2</div>
 </body>
 </html>

--- a/views-thymeleaf/src/test/resources/views/fragment.html
+++ b/views-thymeleaf/src/test/resources/views/fragment.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Home</title>
+</head>
+<body>
+<div>MAIN</div>
+<div th:fragment="thefragment">FRAGMENT</div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds the ability to return a thymeleaf fragment in a view instead of the whole template. Very useful for tools like [htmx.org](https://htmx.org).

This code takes inspiration from the thymeleaf spring integration, found [here](https://github.com/thymeleaf/thymeleaf-spring/blob/f078508ce7d1d823373964551a007cd35fad5270/thymeleaf-spring6/src/main/java/org/thymeleaf/spring6/view/ThymeleafView.java#L269)