### PR TITLE
Update to v6.7.0 of the build plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.3.7"
+micronaut = "4.3.10"
 micronaut-platform = "4.3.1"
 micronaut-docs = '2.0.0'
 micronaut-test = "4.0.1"
@@ -9,8 +9,6 @@ micronaut-security = "4.6.4"
 micronaut-serde = "2.8.1"
 micronaut-validation = "4.4.0"
 micronaut-gradle-plugin = "4.3.3"
-groovy = "4.0.14"
-spock = "2.3-groovy-4.0"
 
 managed-freemarker = "2.3.32"
 managed-handlebars = "4.3.1"
@@ -58,7 +56,7 @@ pebble = { module = "io.pebbletemplates:pebble", version.ref = "pebble" }
 thymeleaf-extras-java8time = { module = "org.thymeleaf.extras:thymeleaf-extras-java8time", version.ref = "thymeleaf-extra-java8time" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
-spock-core = { module = "org.spockframework:spock-core" }
+groovy-json = { module = "org.apache.groovy:groovy-json" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "6.6.2"
+    id("io.micronaut.build.shared.settings") version "6.7.0"
 }
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation(mnSerde.micronaut.serde.api)
     testImplementation(mnSerde.micronaut.serde.jackson)
 
-    testImplementation('org.apache.groovy:groovy-json')
+    testImplementation(libs.groovy.json)
     testImplementation projects.micronautViewsSoy
     testImplementation projects.micronautViewsVelocity
     testImplementation projects.micronautViewsHandlebars


### PR DESCRIPTION
This allows us to remove the Groovy version from the catalog (it will use the version defined in core)

Also removed other unused things