### PR TITLE
build: Fix the 5.1.x branch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=5.2.0-SNAPSHOT
+projectVersion=5.1.1-SNAPSHOT
 projectGroup=io.micronaut.views
 
 title=Micronaut Views

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-micronaut = "4.3.5"
+micronaut = "4.2.3"
 micronaut-platform = "4.0.4"
 micronaut-docs = '2.0.0'
 micronaut-test = "4.0.1"
-micronaut-data = "4.6.1"
+micronaut-data = "4.4.1"
 micronaut-sql = "5.4.0"
 micronaut-security = "4.4.0"
-micronaut-serde = "2.8.1"
+micronaut-serde = "2.7.0"
 micronaut-validation = "4.2.0"
 micronaut-gradle-plugin = "4.2.0"
 groovy = "4.0.14"


### PR DESCRIPTION
The 5.1.x branch seems to have got a few 5.2.x things on it.

This PR resets the versions for the 5.1.x branch (which was in micronaut 4.3.7)