### PR TITLE
feat: add missing morph and refresh methods

### DIFF
--- a/views-core/src/main/java/io/micronaut/views/turbo/TurboStream.java
+++ b/views-core/src/main/java/io/micronaut/views/turbo/TurboStream.java
@@ -487,6 +487,24 @@ public final class TurboStream implements Renderable {
         }
 
         /**
+         * Sets the Turbo action as {@link TurboStreamAction#MORPH}.
+         * @return the Builder
+         */
+        @NonNull
+        public Builder morph() {
+            return action(TurboStreamAction.MORPH);
+        }
+
+        /**
+         * Sets the Turbo action as {@link TurboStreamAction#REFRESH}.
+         * @return the Builder
+         */
+        @NonNull
+        public Builder refresh() {
+            return action(TurboStreamAction.REFRESH);
+        }
+
+        /**
          *
          * @return Builds the {@link TurboStream}.
          */

--- a/views-core/src/test/groovy/io/micronaut/views/turbo/TurboStreamSpec.groovy
+++ b/views-core/src/test/groovy/io/micronaut/views/turbo/TurboStreamSpec.groovy
@@ -26,9 +26,6 @@ import io.micronaut.views.turbo.http.TurboMediaType
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import spock.lang.Specification
-import spock.lang.Unroll
-
-import java.util.function.Consumer
 
 @Property(name = "micronaut.http.client.follow-redirects", value = StringUtils.FALSE)
 @Property(name = "spec.name", value = "TurboStreamSpec")
@@ -38,73 +35,6 @@ class TurboStreamSpec extends Specification {
     @Inject
     @Client("/")
     HttpClient httpClient
-
-    void "convenient methods to set action"(Consumer<TurboStream.Builder> builderConsumer, TurboStreamAction action) {
-        when:
-        TurboStream.Builder builder = TurboStream.builder()
-        builderConsumer.accept(builder)
-        TurboStream turboStream = builder.build()
-
-        then:
-        action == turboStream.action
-
-        where:
-        builderConsumer | action
-        new Consumer<TurboStream.Builder>() {
-            @Override
-            void accept(TurboStream.Builder b) {
-                b.append()
-            }
-        } | TurboStreamAction.APPEND
-        new Consumer<TurboStream.Builder>() {
-            @Override
-            void accept(TurboStream.Builder b) {
-                b.prepend()
-            }
-        } | TurboStreamAction.PREPEND
-        new Consumer<TurboStream.Builder>() {
-            @Override
-            void accept(TurboStream.Builder b) {
-                b.replace()
-            }
-        } | TurboStreamAction.REPLACE
-        new Consumer<TurboStream.Builder>() {
-            @Override
-            void accept(TurboStream.Builder b) {
-                b.update()
-            }
-        } | TurboStreamAction.UPDATE
-        new Consumer<TurboStream.Builder>() {
-            @Override
-            void accept(TurboStream.Builder b) {
-                b.remove()
-            }
-        } | TurboStreamAction.REMOVE
-        new Consumer<TurboStream.Builder>() {
-            @Override
-            void accept(TurboStream.Builder b) {
-                b.before()
-            }
-        } | TurboStreamAction.BEFORE
-        new Consumer<TurboStream.Builder>() {
-            @Override
-            void accept(TurboStream.Builder b) {
-                b.after()
-            }
-        } | TurboStreamAction.AFTER
-        new Consumer<TurboStream.Builder>() {
-            @Override
-            void accept(TurboStream.Builder b) {
-                b.morph()
-            }
-        } | TurboStreamAction.MORPH
-        new Consumer<TurboStream.Builder>() {
-            @Override
-            void accept(TurboStream.Builder b) {
-                b.refresh()
-            }
-        } | TurboStreamAction.REFRESH
-    }
 
     void "turbo stream append with target DOM ID and content"() {
         given:
@@ -146,6 +76,8 @@ class TurboStreamSpec extends Specification {
         TurboStreamAction.BEFORE == TurboStream.builder().targetDomId(domId).before().build().getAction()
         TurboStreamAction.UPDATE == TurboStream.builder().targetDomId(domId).update().build().getAction()
         TurboStreamAction.REPLACE == TurboStream.builder().targetDomId(domId).replace().build().getAction()
+        TurboStreamAction.MORPH == TurboStream.builder().targetDomId(domId).morph().build().getAction()
+        TurboStreamAction.REFRESH == TurboStream.builder().targetDomId(domId).refresh().build().getAction()
     }
 
     void "template is not required"() {
@@ -300,7 +232,6 @@ class TurboStreamSpec extends Specification {
         "<!DOCTYPE html><html><head><title>Page Title</title></head><body><h1>Hello World</h1></body></html>" == responseHtml.body()
     }
 
-    @Unroll
     void "target CSS Query Selector must have letters, digits, hyphens underscores colons, and periods"(String domId) {
         when:
         TurboStream.builder()
@@ -322,7 +253,6 @@ class TurboStreamSpec extends Specification {
         ]
     }
 
-    @Unroll
     void "Illegal argument exception thrown if target CSS Query Selector contains something but letters, digits, hyphens underscores colons, and periods"(String domId) {
         when:
         TurboStream.builder()
@@ -341,7 +271,6 @@ class TurboStreamSpec extends Specification {
         ]
     }
 
-    @Unroll
     void "target CSS Query Selector validation can be disabled"(String domId) {
         when:
         TurboStream.builder()
@@ -361,7 +290,6 @@ class TurboStreamSpec extends Specification {
         ]
     }
 
-    @Unroll
     void "target DOM Id attribute must begin with a letter and may be followed by any number of letters, digits, hyphens underscores colons, and periods"(String domId) {
         when:
         TurboStream.builder()
@@ -384,7 +312,6 @@ class TurboStreamSpec extends Specification {
         ]
     }
 
-    @Unroll
     void "Illegal argument exception thrown if target DOM Id attribute does not begin with a letter and may be followed by any number of letters, digits, hyphens underscores colons, and periods"(String domId) {
         when:
         TurboStream.builder()
@@ -408,7 +335,6 @@ class TurboStreamSpec extends Specification {
         ]
     }
 
-    @Unroll
     void "Target DOM Id attribute validation can be disabled"(String domId) {
         when:
         TurboStream.builder()
@@ -511,14 +437,14 @@ class TurboStreamSpec extends Specification {
         }
 
         @Produces(TurboMediaType.TURBO_STREAM)
-        @TurboView(value = "fragments/message", action=TurboStreamAction.REFRESH, requestId = "abcd-1234")
+        @TurboView(value = "fragments/message", action = TurboStreamAction.REFRESH, requestId = "abcd-1234")
         @Get("/requestId")
         String requestId() {
             "Hello World"
         }
 
         @Produces(TurboMediaType.TURBO_STREAM)
-        @TurboView(value = "fragments/message", action=TurboStreamAction.MORPH, childrenOnly = true)
+        @TurboView(value = "fragments/message", action = TurboStreamAction.MORPH, childrenOnly = true)
         @Get("/childrenOnly")
         String childrenOnly() {
             "Hello World"

--- a/views-core/src/test/groovy/io/micronaut/views/turbo/TurboStreamSpec.groovy
+++ b/views-core/src/test/groovy/io/micronaut/views/turbo/TurboStreamSpec.groovy
@@ -28,6 +28,8 @@ import jakarta.inject.Singleton
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.util.function.Consumer
+
 @Property(name = "micronaut.http.client.follow-redirects", value = StringUtils.FALSE)
 @Property(name = "spec.name", value = "TurboStreamSpec")
 @MicronautTest
@@ -36,6 +38,73 @@ class TurboStreamSpec extends Specification {
     @Inject
     @Client("/")
     HttpClient httpClient
+
+    void "convenient methods to set action"(Consumer<TurboStream.Builder> builderConsumer, TurboStreamAction action) {
+        when:
+        TurboStream.Builder builder = TurboStream.builder()
+        builderConsumer.accept(builder)
+        TurboStream turboStream = builder.build()
+
+        then:
+        action == turboStream.action
+
+        where:
+        builderConsumer | action
+        new Consumer<TurboStream.Builder>() {
+            @Override
+            void accept(TurboStream.Builder b) {
+                b.append()
+            }
+        } | TurboStreamAction.APPEND
+        new Consumer<TurboStream.Builder>() {
+            @Override
+            void accept(TurboStream.Builder b) {
+                b.prepend()
+            }
+        } | TurboStreamAction.PREPEND
+        new Consumer<TurboStream.Builder>() {
+            @Override
+            void accept(TurboStream.Builder b) {
+                b.replace()
+            }
+        } | TurboStreamAction.REPLACE
+        new Consumer<TurboStream.Builder>() {
+            @Override
+            void accept(TurboStream.Builder b) {
+                b.update()
+            }
+        } | TurboStreamAction.UPDATE
+        new Consumer<TurboStream.Builder>() {
+            @Override
+            void accept(TurboStream.Builder b) {
+                b.remove()
+            }
+        } | TurboStreamAction.REMOVE
+        new Consumer<TurboStream.Builder>() {
+            @Override
+            void accept(TurboStream.Builder b) {
+                b.before()
+            }
+        } | TurboStreamAction.BEFORE
+        new Consumer<TurboStream.Builder>() {
+            @Override
+            void accept(TurboStream.Builder b) {
+                b.after()
+            }
+        } | TurboStreamAction.AFTER
+        new Consumer<TurboStream.Builder>() {
+            @Override
+            void accept(TurboStream.Builder b) {
+                b.morph()
+            }
+        } | TurboStreamAction.MORPH
+        new Consumer<TurboStream.Builder>() {
+            @Override
+            void accept(TurboStream.Builder b) {
+                b.refresh()
+            }
+        } | TurboStreamAction.REFRESH
+    }
 
     void "turbo stream append with target DOM ID and content"() {
         given:


### PR DESCRIPTION
We forgot these methods in: #773

Close: #772 