### PR TITLE
React Renderer: use the resource resolver API to locate the server bundle

### DIFF
--- a/src/main/docs/guide/views/templates/react/reactpreparingjs.adoc
+++ b/src/main/docs/guide/views/templates/react/reactpreparingjs.adoc
@@ -25,7 +25,7 @@ This Webpack config does several things:
 
 * It polyfills APIs that lack a native implementation in the GraalJS engine.
 * It ensures the output is a native Javascript module.
-* It names the result `ssr-components.mjs` which is the only name Micronaut React SSR accepts. All components must be in one server side bundle currently.
+* It names the result `ssr-components.mjs`. You can use any name, but it's looked for under this name in the `views` resource directory by default. All components must be in one server side bundle.
 * It makes the `SERVER` variable be statically true when the Javascript is being bundled for server-side rendering. This allows you to include/exclude code blocks at bundle optimization time.
 
 You can use such a config by running `npx webpack --mode production --config webpack.server.js`. Add the `--watch` flag if you want the bundle to be recreated whenever an input file changes. Micronaut React SSR will notice if the bundle file has changed on disk and reload it (see <<react-dev-mode,Development>>).

--- a/src/main/docs/guide/views/templates/react/reactsettingproperties.adoc
+++ b/src/main/docs/guide/views/templates/react/reactsettingproperties.adoc
@@ -3,9 +3,11 @@ React SSR needs some Micronaut application properties to be set.
 [configuration]
 ----
 micronaut:
-  # Point to client and server JS
+  # Point to the server-side JS. This value is the default.
   views:
-    folder: classes/views
+    react:
+      server-bundle-path: "classpath:views/ssr-components.mjs"
+
   router:
     static-resources:
       js:

--- a/views-react/src/main/java/io/micronaut/views/react/JSContextPool.java
+++ b/views-react/src/main/java/io/micronaut/views/react/JSContextPool.java
@@ -82,7 +82,7 @@ class JSContextPool implements ApplicationEventListener<FileChangedEvent> {
 
     @Override
     public synchronized void onApplicationEvent(FileChangedEvent event) {
-        if (event.getPath().equals(paths.bundlePath) && event.getEventType() != WatchEventType.DELETE) {
+        if (paths.bundlePath != null && event.getPath().equals(paths.bundlePath) && event.getEventType() != WatchEventType.DELETE) {
             LOG.info("Reloading Javascript bundle due to file change.");
             versionCounter++;
         }

--- a/views-react/src/main/java/io/micronaut/views/react/ReactViewsRendererConfiguration.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactViewsRendererConfiguration.java
@@ -35,7 +35,7 @@ public interface ReactViewsRendererConfiguration {
     String DEFAULT_CLIENT_BUNDLE_URL = "/static/client.js";
 
     /** The default value for {@link #getServerBundlePath()}. */
-    String DEFAULT_SERVER_BUNDLE_PATH = "ssr-components.mjs";
+    String DEFAULT_SERVER_BUNDLE_PATH = "classpath:views/ssr-components.mjs";
 
     /** The default value for {@link #getRenderScript()}. */
     String DEFAULT_RENDER_SCRIPT = "classpath:/io/micronaut/views/react/react.js";

--- a/views-react/src/test/groovy/io/micronaut/views/react/PreactViewRenderSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/PreactViewRenderSpec.groovy
@@ -12,9 +12,8 @@ import spock.lang.Specification
  * provide.
  */
 @MicronautTest(startApplication = false)
-@Property(name = "micronaut.views.folder", value = "src/test/resources/views")
 @Property(name = "micronaut.views.react.client-bundle-url", value = "/static/client.preact.js")
-@Property(name = "micronaut.views.react.server-bundle-path", value = "ssr-components.preact.mjs")
+@Property(name = "micronaut.views.react.server-bundle-path", value = "classpath:views/ssr-components.preact.mjs")
 @Property(name = "micronaut.views.react.render-script", value = "classpath:/io/micronaut/views/react/preact.js")
 class PreactViewRenderSpec extends Specification {
     @Inject

--- a/views-react/src/test/groovy/io/micronaut/views/react/ReactViewRenderSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/ReactViewRenderSpec.groovy
@@ -8,7 +8,7 @@ import jakarta.inject.Inject
 import spock.lang.Specification
 
 @MicronautTest(startApplication = false, rebuildContext = true)
-@Property(name = "micronaut.views.folder", value = "src/test/resources/views")
+@Property(name = "micronaut.views.react.server-bundle-path", value = "classpath:views/ssr-components.mjs")
 class ReactViewRenderSpec extends Specification {
     @Inject
     ReactViewsRenderer<?> renderer;

--- a/views-react/src/test/groovy/io/micronaut/views/react/SandboxReactRenderSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/SandboxReactRenderSpec.groovy
@@ -9,7 +9,7 @@ import spock.lang.FailsWith
 import spock.lang.Specification
 
 @MicronautTest(startApplication = false, rebuildContext = true)
-@Property(name = "micronaut.views.folder", value = "src/test/resources/views")
+@Property(name = "micronaut.views.react.server-bundle-path", value = "classpath:views/ssr-components.mjs")
 @Property(name = "micronaut.views.react.sandbox", value = "true")
 class SandboxReactRenderSpec extends Specification {
     @Inject


### PR DESCRIPTION
This makes paths work as you'd expect in the dev environment.