### PR TITLE
ReactJS: Fix exception hang and improve docs

### DIFF
--- a/src/main/docs/guide/views/templates/react.adoc
+++ b/src/main/docs/guide/views/templates/react.adoc
@@ -20,6 +20,19 @@ To use React SSR you need to add two dependencies.
 
 dependency:micronaut-views-react[groupId="io.micronaut.views"]
 
+== Scaffold a Micronaut frontend/backend project
+
+You can easily create a new ReactJS-based project from scratch using https://micronaut.io/launch[Micronaut Launch], the built-in IntelliJ Micronaut wizard, or the https://micronaut.io/download/[`mn` CLI tool]:
+
+[source,shell]
+----
+$ mn create-app --features=views-react my-cool-project
+----
+
+This will create a complete project with `webpack` based bundling for client and server side rendering, a pre-configured Micronaut Views React app, and a sample component/page handler.  Javascript package installation and bundling is handled by Gradle or Maven, depending on the value of the `--build` flag you pass to `mn` (we recommend Gradle as it will be much faster). The build scripts will even download NodeJS for you, so you don't need anything other than a JDK to get started.
+
+== Configuration properties
+
 The properties used can be customized by overriding the values of:
 
 include::{includedir}configurationProperties/io.micronaut.views.react.ReactViewsRendererConfiguration.adoc[]

--- a/views-react/src/main/java/io/micronaut/views/react/ReactViewsRenderer.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactViewsRenderer.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.beans.BeanMap;
 import io.micronaut.core.io.Writable;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.exceptions.MessageBodyException;
 import io.micronaut.views.ViewsRenderer;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -46,9 +47,6 @@ public class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpReque
     @Inject
     JSContextPool contextPool;
 
-    @Inject
-    JSBundlePaths jsBundlePaths;
-
     /**
      * Construct this renderer. Don't call it yourself, as Micronaut Views will set it up for you.
      */
@@ -71,6 +69,9 @@ public class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpReque
             JSContext context = contextPool.acquire();
             try {
                 render(viewName, props, writer, context, request);
+            } catch (Exception e) {
+                // If we don't wrap and rethrow, the exception is swallowed and the request hangs.
+                throw new MessageBodyException("Could not render component " + viewName, e);
             } finally {
                 contextPool.release(context);
             }


### PR DESCRIPTION
1. Mention how to create a new project using Micronaut Launch/Starter in the docs.
2. Fix a bug reported by a user, in which forgetting to add `@Introspected` to a props object could cause  the request to silently hang.