### PR TITLE
build: update org.json:json to patched version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ managed-jstachio = "1.3.6"
 managed-jte = "3.1.12"
 managed-rocker = "1.4.0"
 managed-soy = "2023-09-13"
+org-json = "20231013"
 managed-thymeleaf = "3.1.2.RELEASE"
 managed-velocity = "2.3"
 
@@ -47,6 +48,7 @@ managed-jte = { module = "gg.jte:jte", version.ref = "managed-jte" }
 managed-jte-kotlin = { module = "gg.jte:jte-kotlin", version.ref = "managed-jte" }
 managed-rocker-runtime = { module = "com.fizzed:rocker-runtime", version.ref = "managed-rocker" }
 managed-soy = { module = "com.google.template:soy", version.ref = "managed-soy" }
+org-json = { module = "org.json:json", version.ref = "org-json" }
 managed-thymeleaf = { module = "org.thymeleaf:thymeleaf", version.ref = "managed-thymeleaf" }
 managed-velocity-engine-core = { module = "org.apache.velocity:velocity-engine-core", version.ref = "managed-velocity" }
 

--- a/views-soy/build.gradle.kts
+++ b/views-soy/build.gradle.kts
@@ -1,12 +1,15 @@
 plugins {
-    id "io.micronaut.build.internal.views-module"
+    id("io.micronaut.build.internal.views-module")
 }
 
 dependencies {
     annotationProcessor(mnValidation.micronaut.validation.processor)
 
-    api projects.micronautViewsCore
-    api(libs.managed.soy)
+    api(projects.micronautViewsCore)
+    api(libs.managed.soy) {
+        exclude(group = "org.json", module = "json")
+    }
+    implementation(libs.org.json)
 
     compileOnly(mn.micronaut.management)
     compileOnly(mnValidation.micronaut.validation)


### PR DESCRIPTION
Close: https://github.com/micronaut-projects/micronaut-views/issues/849

Soy brings `org.json:json` as a transtivite dependency. Unfortunately, it brings https://ossindex.sonatype.org/component/pkg:maven/org.json/json@20230618 which is affected by a HIGH CVE.

There is no version of soy patched.

I reported an issue: https://github.com/google/closure-templates/issues/2128

This PR forces `org.json:json` to first patched version.

I have verified with the [sonatype scan gradle plugin](http://localhost/sergiodelamo.com/blog/2024-08-08-sonatype-scan-gradle-plugin.html) this PR fixes the issue.

