### PR TITLE
ReactJS: Fixes to proxy object wrapping

### DIFF
--- a/views-react/src/main/java/io/micronaut/views/react/ReactViewsRenderer.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactViewsRenderer.java
@@ -25,7 +25,6 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.Value;
-import org.graalvm.polyglot.proxy.ProxyObject;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -97,8 +96,8 @@ public class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpReque
         // We wrap the props object so we can use Micronaut's compile-time reflection implementation.
         // This should be more native-image friendly (no need to write reflection config files), and
         // might also be faster.
-        ProxyObject propsObj = new ProxyObjectWithIntrospectableSupport(context.polyglotContext, props);
-        context.render.execute(component, propsObj, renderCallback, reactConfiguration.getClientBundleURL(), request);
+        Value guestProps = ProxyObjectWithIntrospectableSupport.wrap(context.polyglotContext, props);
+        context.render.executeVoid(component, guestProps, renderCallback, reactConfiguration.getClientBundleURL(), request);
     }
 
     /**

--- a/views-react/src/test/groovy/io/micronaut/views/react/IntrospectableBeansAreProxiedSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/IntrospectableBeansAreProxiedSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.views.react
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyObject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class IntrospectableBeansAreProxiedSpec extends Specification {
+    @Inject
+    JSContextPool contextPool
+
+    void "introspectable bean can be proxied"() {
+        given:
+        def jsContext = contextPool.acquire()
+        def context = jsContext.polyglotContext
+        def bean = new SomeBean("foo value", "bar value", new SomeBean.InnerBean(10, Map.of("key", 123), List.of("one", "two", "three")))
+
+        when:
+        ProxyObject proxy = ProxyObjectWithIntrospectableSupport.wrap(context, bean).asProxyObject()
+        context.getBindings("js").putMember("bean", proxy)
+
+        then:
+        proxy.getMember("foo") == context.asValue("foo value")
+        proxy.getMember("innerBean") instanceof Value
+
+        when:
+        ProxyObject innerBean = ((Value) proxy.getMember("innerBean")).asProxyObject()
+
+        then:
+        innerBean instanceof ProxyObjectWithIntrospectableSupport
+
+        when:
+        ProxyObject innerBeanMap = ((Value) innerBean.getMember("map")).asProxyObject()
+
+        then:
+        ((Value) innerBeanMap.getMember("key")).asInt() == 123
+        context.eval("js", "bean.innerBean.map[\"key\"]").asInt() == 123
+    }
+}

--- a/views-react/src/test/groovy/io/micronaut/views/react/PreactViewRenderSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/PreactViewRenderSpec.groovy
@@ -21,7 +21,7 @@ class PreactViewRenderSpec extends Specification {
 
     void "views can be rendered with basic props and no request"() {
         when:
-        Writable writable = renderer.render("App", ["name": "Mike", "obj": new SomeBean("foo", null)], null)
+        Writable writable = renderer.render("App", TestProps.basic, null)
         String result = new StringWriter().with {
             writable.writeTo(it)
             it.toString()
@@ -39,7 +39,7 @@ class PreactViewRenderSpec extends Specification {
         req.getUri() >> URI.create("https://localhost/demopage")
 
         when:
-        Writable writable = renderer.render("App", ["name": "Mike", "obj": new SomeBean("foo", null)], req)
+        Writable writable = renderer.render("App", TestProps.basic, req)
         String result = new StringWriter().with {
             writable.writeTo(it)
             it.toString()

--- a/views-react/src/test/groovy/io/micronaut/views/react/ReactViewRenderSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/ReactViewRenderSpec.groovy
@@ -16,7 +16,7 @@ class ReactViewRenderSpec extends Specification {
 
     void "views can be rendered with basic props"() {
         when:
-        Writable writable = renderer.render("App", ["name": "Mike", "someNull": null, "obj": new SomeBean("foo", null)], null)
+        Writable writable = renderer.render("App", TestProps.basic, null)
         String result = new StringWriter().with {
             writable.writeTo(it)
             it.toString()
@@ -36,7 +36,7 @@ class ReactViewRenderSpec extends Specification {
         req.getUri() >> URI.create("https://localhost/demopage")
 
         when:
-        Writable writable = renderer.render("App", ["name": "Mike", "obj": new SomeBean("foo", null)], req)
+        Writable writable = renderer.render("App", TestProps.basic, req)
         String result = new StringWriter().with {
             writable.writeTo(it)
             it.toString()
@@ -50,7 +50,7 @@ class ReactViewRenderSpec extends Specification {
 
     void "host access is OK if sandbox is disabled"() {
         when:
-        renderer.render("App", ["name": "Mike", "triggerSandbox": true, "obj": new SomeBean("foo", null)], null).writeTo(OutputStream.nullOutputStream())
+        renderer.render("App", TestProps.triggerSandbox, null).writeTo(OutputStream.nullOutputStream())
 
         then:
         notThrown(MessageBodyException)

--- a/views-react/src/test/groovy/io/micronaut/views/react/ReactViewRenderSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/ReactViewRenderSpec.groovy
@@ -27,6 +27,7 @@ class ReactViewRenderSpec extends Specification {
         result.contains("Reading a property works: <!-- -->foo")
         result.contains("Reading a null works: </p>")
         result.contains("\"name\":\"Mike\"")
+        result.contains("\"innerBean\":{\"a\":10,\"list\":[\"one\",\"two\"],\"map\":{}}")
         result.contains("Calling a method works: <!-- -->Goodbye Bob!")
     }
 

--- a/views-react/src/test/groovy/io/micronaut/views/react/SandboxReactRenderSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/SandboxReactRenderSpec.groovy
@@ -19,11 +19,8 @@ class SandboxReactRenderSpec extends Specification {
     // this unit test can be enabled.
     @FailsWith(BeanInstantiationException)
     void "views can be rendered with sandboxing enabled"() {
-        given:
-        def props = ["name": "Mike", "obj": new SomeBean("bar", null)]
-
         when:
-        Writable writable = renderer.render("App", props, null)
+        Writable writable = renderer.render("App", TestProps.basic, null)
         String result = new StringWriter().with {
             writable.writeTo(it)
             it.toString()
@@ -36,7 +33,7 @@ class SandboxReactRenderSpec extends Specification {
 
     void "host types are inaccessible with the sandbox enabled"() {
         when:
-        Writable writable = renderer.render("App", ["name": "Mike", "triggerSandbox": true, "obj": new SomeBean("foo", null)], null)
+        Writable writable = renderer.render("App", TestProps.triggerSandbox, null)
         new StringWriter().with {
             writable.writeTo(it)
             it.toString()

--- a/views-react/src/test/groovy/io/micronaut/views/react/TestProps.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/TestProps.groovy
@@ -1,6 +1,6 @@
 package io.micronaut.views.react
 
 class TestProps {
-    static def basic = ["name": "Mike", "someNull": null, "obj": new SomeBean("foo", null)]
+    static def basic = ["name": "Mike", "someNull": null, "obj": new SomeBean("foo", null, new SomeBean.InnerBean(10, Map.of(), List.of("one", "two")))]
     static def triggerSandbox = basic + ["triggerSandbox": true]
 }

--- a/views-react/src/test/groovy/io/micronaut/views/react/TestProps.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/TestProps.groovy
@@ -1,0 +1,6 @@
+package io.micronaut.views.react
+
+class TestProps {
+    static def basic = ["name": "Mike", "someNull": null, "obj": new SomeBean("foo", null)]
+    static def triggerSandbox = basic + ["triggerSandbox": true]
+}

--- a/views-react/src/test/java/io/micronaut/views/react/SomeBean.java
+++ b/views-react/src/test/java/io/micronaut/views/react/SomeBean.java
@@ -4,6 +4,9 @@ import io.micronaut.context.annotation.Executable;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Test bean accessed from inside the sandbox.
  */
@@ -11,10 +14,12 @@ import io.micronaut.core.annotation.Nullable;
 public class SomeBean {
     private final String foo;
     private final @Nullable String bar;
+    private final InnerBean innerBean;
 
-    SomeBean(String foo, String bar) {
+    SomeBean(String foo, String bar, InnerBean innerBean) {
         this.foo = foo;
         this.bar = bar;
+        this.innerBean = innerBean;
     }
 
     public String getFoo() {
@@ -25,8 +30,37 @@ public class SomeBean {
         return bar;
     }
 
+    public InnerBean getInnerBean() {
+        return innerBean;
+    }
+
     @Executable
     public String sayGoodbye(String name) {
         return "Goodbye " + name + "!";
+    }
+
+    @Introspected
+    public static class InnerBean {
+        private final int a;
+        private final Map<Object, Object> map;
+        private final List<String> list;
+
+        InnerBean(int a, Map<Object, Object> map, List<String> list) {
+            this.a = a;
+            this.map = map;
+            this.list = list;
+        }
+
+        public Map<Object, Object> getMap() {
+            return map;
+        }
+
+        public int getA() {
+            return a;
+        }
+
+        public List<String> getList() {
+            return list;
+        }
     }
 }


### PR DESCRIPTION
This resolves some more bugs reported by a user. This time I sent them a test JAR and they confirmed that everything now works and they could remove their previous workarounds, so I hope this is the last round of fixes required.

Specifically these commits:

- Refactor the code to ensure map values are always mapped
- Adds unit tests specifically for the proxy mapper
- Adds examples of mapping lists

