### PR TITLE
Describe request attribute containing CSP nonce

### DIFF
--- a/src/main/docs/guide/views/security/csp.adoc
+++ b/src/main/docs/guide/views/security/csp.adoc
@@ -45,9 +45,10 @@ Content-Security-Policy: default-src https: self:; script-src 'nonce-4ze2IRazk4Y
 The nonce value can be accessed on the server as a request attribute named `cspNonce`. This is the value to use
 in the `nonce` attribute on `script` and related tags.  For example (adapt as appropriate for your template language):
 
-```html
+[source,html]
+----
 <script type="text/javascript" src="/path/to/script.js" nonce="${cspNonce}" />
-```
+----
 
 Inline scripts which aren't otherwise whitelisted will be declined for execution, unless CSP is operating in report-only
 mode. Inline scripts can be whitelisted with the syntax:

--- a/src/main/docs/guide/views/security/csp.adoc
+++ b/src/main/docs/guide/views/security/csp.adoc
@@ -42,6 +42,13 @@ That's it! After applying the above configuration, HTTP responses might include 
 Content-Security-Policy: default-src https: self:; script-src 'nonce-4ze2IRazk4Yu/j5K6SEzjA';
 ```
 
+The nonce value can be accessed on the server as a request attribute named `cspNonce`. This is the value to use
+in the `nonce` attribute on `script` and related tags.  For example (adapt as appropriate for your template language):
+
+```html
+<script type="text/javascript" src="/path/to/script.js" nonce="${cspNonce}" />
+```
+
 Inline scripts which aren't otherwise whitelisted will be declined for execution, unless CSP is operating in report-only
 mode. Inline scripts can be whitelisted with the syntax:
 


### PR DESCRIPTION
This update explains where the generated nonce value can be accessed on the server, so that template systems utilizing CSP can be able to access the value. Provides a trivial example.