### PR TITLE
`Context` use BeanPool create

### DIFF
--- a/views-react/src/main/java/io/micronaut/views/react/ReactJSBeanFactory.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactJSBeanFactory.java
@@ -83,6 +83,7 @@ final class ReactJSBeanFactory {
     }
 
     @ReactBean
+    @Prototype
     Context polyglotContext(@ReactBean Engine engine,
                             @ReactBean HostAccess hostAccess,
                             ReactViewsRendererConfiguration configuration) {

--- a/views-react/src/main/java/io/micronaut/views/react/ReactJSBeanFactory.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactJSBeanFactory.java
@@ -83,7 +83,6 @@ final class ReactJSBeanFactory {
     }
 
     @ReactBean
-    @Singleton
     Context polyglotContext(@ReactBean Engine engine,
                             @ReactBean HostAccess hostAccess,
                             ReactViewsRendererConfiguration configuration) {


### PR DESCRIPTION
`Context` is a “share-nothing” model, is non thread safe.

@see https://www.graalvm.org/latest/reference-manual/js/Multithreading/

So, create new `Context` use by BeanPool.