### PR TITLE
docs: fix Soy renaming guide

### DIFF
--- a/src/main/docs/guide/views/templates/soy/soyfeaturesrenaming.adoc
+++ b/src/main/docs/guide/views/templates/soy/soyfeaturesrenaming.adoc
@@ -72,7 +72,7 @@ public class RewriteMapProvider implements SoyNamingMapProvider {
     try (InputStream inputStream = mapPath.openStream()) {
       return new ObjectMapper().readValue(inputStream, new TypeReference<Map<String, String>>() { });
     } catch (IOException e) {
-      //handle `JsonMappingException` and `IOException`, if, for instance, you're using Jackson
+      // handle `JsonMappingException` and `IOException`, if, for instance, you're using Jackson
       throw new RuntimeException(e);
     }
   }

--- a/src/main/docs/guide/views/templates/soy/soyfeaturesrenaming.adoc
+++ b/src/main/docs/guide/views/templates/soy/soyfeaturesrenaming.adoc
@@ -17,7 +17,7 @@ micronaut:
   views:
     soy:
       enabled: true
-      renaming: true
+      renaming-enabled: true
 ----
 
 2. When building your styles with GSS, or a similar tool, generate a rewrite map:
@@ -69,24 +69,24 @@ public class RewriteMapProvider implements SoyNamingMapProvider {
    */
   @Nullable
   private static Map<String, String> loadMapFromJSON(URL mapPath) {
-    try {
-      return new ObjectMapper().readValue(mapPath, new TypeReference<Map<String, String>>() { });
-    } catch (Throwable thr) {
+    try (InputStream inputStream = mapPath.openStream()) {
+      return new ObjectMapper().readValue(inputStream, new TypeReference<Map<String, String>>() { });
+    } catch (IOException e) {
       //handle `JsonMappingException` and `IOException`, if, for instance, you're using Jackson
-      throw new RuntimeException(thr);
+      throw new RuntimeException(e);
     }
   }
 
   static {
     final URL mapPath =
-        SoyRenderConfigProvider.class.getClassLoader().getResource(RENAMING_MAP_NAME);
+        RewriteMapProvider.class.getClassLoader().getResource(RENAMING_MAP_NAME);
     if (mapPath != null) {
       // load the renaming map
       final Map<String, String> cssRenamingMap = loadMapFromJSON(mapPath);
-      if (renamingMapRaw != null) {
+      if (cssRenamingMap != null) {
         CSS_RENAMING_MAP = new SoyCssRenamingMap() {
           @Nullable @Override
-          public String get(@NotNull String className) {
+          public String get(String className) {
             // (or whatever logic you need to rewrite the class)
             return cssRenamingMap.get(className);
           }


### PR DESCRIPTION
## Summary

- Correct the Soy renaming configuration example to use `renaming-enabled`, matching the generated configuration reference.
- Fix the `RewriteMapProvider` example so the class reference, map null check, and Jackson resource loading code are compileable.

## Validation

- `./gradlew clean publishGuide`
- `./gradlew :micronaut-views-soy:test`
- `./gradlew docs`
- Throwaway `javac` compile of the corrected `RewriteMapProvider` sample against the project Soy classes, Soy 2024-02-26, Jakarta Inject, JSpecify, and Jackson 3 jars.

Paperclip child issue: MNG-471.

---
###### ✨ This message was AI-generated using gpt-5.5
