### PR TITLE
Add shared views renderer configuration

### DIFF
--- a/views-core/src/main/java/io/micronaut/views/ViewsRendererConfiguration.java
+++ b/views-core/src/main/java/io/micronaut/views/ViewsRendererConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,25 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.views.rocker;
+package io.micronaut.views;
 
-import io.micronaut.views.ViewsRendererConfiguration;
+import io.micronaut.core.util.Toggleable;
+import org.jspecify.annotations.NonNull;
 
 /**
- * Configuration for {@link RockerViewsRenderer}.
+ * Configuration for {@link ViewsRenderer}.
  *
- * @author Sam Adams
- * @since 1.3.2
+ * @author Sergio del Amo
+ * @since 6.2.0
  */
-public interface RockerViewsRendererConfiguration extends ViewsRendererConfiguration {
-    /**
-     * @return If hot reloading is enabled
-     */
-    boolean isHotReloading();
+public interface ViewsRendererConfiguration extends Toggleable {
 
     /**
-     * @return If relaxed binding is enabled for dynamic templates
+     * @return Default extension for templates
      */
-    boolean isRelaxed();
-
+    @NonNull
+    String getDefaultExtension();
 }

--- a/views-core/src/main/java/io/micronaut/views/ViewsRendererConfiguration.java
+++ b/views-core/src/main/java/io/micronaut/views/ViewsRendererConfiguration.java
@@ -16,7 +16,7 @@
 package io.micronaut.views;
 
 import io.micronaut.core.util.Toggleable;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Configuration for {@link ViewsRenderer}.
@@ -29,6 +29,5 @@ public interface ViewsRendererConfiguration extends Toggleable {
     /**
      * @return Default extension for templates
      */
-    @NonNull
-    String getDefaultExtension();
+    @Nullable String getDefaultExtension();
 }

--- a/views-freemarker/build.gradle
+++ b/views-freemarker/build.gradle
@@ -24,4 +24,8 @@ dependencies {
     testImplementation(mnValidation.micronaut.validation)
 
     testImplementation(mn.snakeyaml)
+
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
 }

--- a/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfiguration.java
+++ b/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfiguration.java
@@ -16,7 +16,6 @@
 package io.micronaut.views.freemarker;
 
 import freemarker.template.Version;
-import io.micronaut.core.util.Toggleable;
 import io.micronaut.views.ViewsRendererConfiguration;
 
 /**

--- a/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfiguration.java
+++ b/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfiguration.java
@@ -17,20 +17,15 @@ package io.micronaut.views.freemarker;
 
 import freemarker.template.Version;
 import io.micronaut.core.util.Toggleable;
+import io.micronaut.views.ViewsRendererConfiguration;
 
 /**
  * Configuration for {@link FreemarkerViewsRenderer}.
- * 
+ *
  * @author Jerónimo López
  * @since 1.1
  */
-public interface FreemarkerViewsRendererConfiguration extends Toggleable {
-
-    /**
-     * @return Default extension for templates
-     */
-    String getDefaultExtension();
-
+public interface FreemarkerViewsRendererConfiguration extends ViewsRendererConfiguration {
     /**
      * @return An optional Freemarker version number
      */

--- a/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfigurationProperties.java
+++ b/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfigurationProperties.java
@@ -113,7 +113,8 @@ public class FreemarkerViewsRendererConfigurationProperties extends Configuratio
      *
      * @return The default extension to use
      */
-    public @NonNull String getDefaultExtension() {
+    @Override
+    public @Nullable String getDefaultExtension() {
         return defaultExtension;
     }
 

--- a/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfigurationProperties.java
+++ b/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfigurationProperties.java
@@ -27,6 +27,7 @@ import io.micronaut.core.naming.conventions.StringConvention;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.views.ViewsConfiguration;
 import io.micronaut.views.ViewsConfigurationProperties;
+import jakarta.inject.Named;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import java.util.Properties;
@@ -47,6 +48,7 @@ import java.util.Properties;
  * @author Jerónimo López
  * @since 1.1
  */
+@Named("freemarker")
 @Requires(classes = freemarker.template.Configuration.class)
 @ConfigurationProperties(FreemarkerViewsRendererConfigurationProperties.PREFIX)
 public class FreemarkerViewsRendererConfigurationProperties extends Configuration implements FreemarkerViewsRendererConfiguration {

--- a/views-freemarker/src/test/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfigurationTest.java
+++ b/views-freemarker/src/test/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfigurationTest.java
@@ -1,0 +1,17 @@
+package io.micronaut.views.freemarker;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.views.ViewsRendererConfiguration;
+import jakarta.inject.Named;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+@MicronautTest(startApplication = false)
+class FreemarkerViewsRendererConfigurationTest {
+
+    @Test
+    void testNamedViewRendererConfiguration(@Named("freemarker") ViewsRendererConfiguration config) {
+        assertInstanceOf(FreemarkerViewsRendererConfiguration.class, config);
+    }
+}

--- a/views-handlebars/build.gradle
+++ b/views-handlebars/build.gradle
@@ -23,4 +23,8 @@ dependencies {
     testImplementation(mnValidation.micronaut.validation)
 
     testImplementation(mn.snakeyaml)
+
+    testImplementation(mnTest.junit.jupiter.api)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
 }

--- a/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRendererConfiguration.java
+++ b/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRendererConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.views.handlebars;
 
-import io.micronaut.core.util.Toggleable;
+import io.micronaut.views.ViewsRendererConfiguration;
 
 /**
  * Configuration for {@link HandlebarsViewsRenderer}.
@@ -23,10 +23,5 @@ import io.micronaut.core.util.Toggleable;
  * @author Sergio del Amo
  * @since 1.0
  */
-public interface HandlebarsViewsRendererConfiguration extends Toggleable {
-
-    /**
-     * @return Default extension for templates
-     */
-    String getDefaultExtension();
+public interface HandlebarsViewsRendererConfiguration extends ViewsRendererConfiguration {
 }

--- a/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRendererConfigurationProperties.java
+++ b/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRendererConfigurationProperties.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.views.ViewsConfigurationProperties;
 import jakarta.inject.Named;
+import org.jspecify.annotations.Nullable;
 
 /**
  * {@link ConfigurationProperties} implementation of {@link HandlebarsViewsRendererConfiguration}.
@@ -67,7 +68,7 @@ public class HandlebarsViewsRendererConfigurationProperties implements Handlebar
      * @return Default extension for templates. By default {@value #DEFAULT_EXTENSION}.
      */
     @Override
-    public String getDefaultExtension() {
+    public @Nullable String getDefaultExtension() {
         return defaultExtension;
     }
 

--- a/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRendererConfigurationProperties.java
+++ b/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRendererConfigurationProperties.java
@@ -18,6 +18,7 @@ package io.micronaut.views.handlebars;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.views.ViewsConfigurationProperties;
+import jakarta.inject.Named;
 
 /**
  * {@link ConfigurationProperties} implementation of {@link HandlebarsViewsRendererConfiguration}.
@@ -25,6 +26,7 @@ import io.micronaut.views.ViewsConfigurationProperties;
  * @author Sergio del Amo
  * @since 1.0
  */
+@Named("handlebars")
 @ConfigurationProperties(HandlebarsViewsRendererConfigurationProperties.PREFIX)
 public class HandlebarsViewsRendererConfigurationProperties implements HandlebarsViewsRendererConfiguration {
 

--- a/views-handlebars/src/test/java/io/micronaut/views/handlebars/HandlebarsViewsRendererConfigurationTest.java
+++ b/views-handlebars/src/test/java/io/micronaut/views/handlebars/HandlebarsViewsRendererConfigurationTest.java
@@ -1,0 +1,20 @@
+package io.micronaut.views.handlebars;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.views.ViewsRendererConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class HandlebarsViewsRendererConfigurationTest {
+
+    @Test
+    void testNamedViewRendererConfiguration() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ViewsRendererConfiguration configuration = context.getBean(ViewsRendererConfiguration.class, Qualifiers.byName("handlebars"));
+
+            assertInstanceOf(HandlebarsViewsRendererConfiguration.class, configuration);
+        }
+    }
+}

--- a/views-pebble/build.gradle
+++ b/views-pebble/build.gradle
@@ -21,4 +21,8 @@ dependencies {
     testImplementation(mnValidation.micronaut.validation)
 
     testImplementation(mn.snakeyaml)
+
+    testImplementation(mnTest.junit.jupiter.api)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
 }

--- a/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleConfiguration.java
+++ b/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleConfiguration.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.views.pebble;
 
-import io.micronaut.core.util.Toggleable;
 import io.micronaut.views.ViewsRendererConfiguration;
 
 /**

--- a/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleConfiguration.java
+++ b/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleConfiguration.java
@@ -16,6 +16,7 @@
 package io.micronaut.views.pebble;
 
 import io.micronaut.core.util.Toggleable;
+import io.micronaut.views.ViewsRendererConfiguration;
 
 /**
  * Configuration for {@link PebbleViewsRenderer}.
@@ -23,21 +24,15 @@ import io.micronaut.core.util.Toggleable;
  * @author Ecmel Ercan
  * @since 2.2.0
  */
-public interface PebbleConfiguration extends Toggleable {
-
-    /**
-     * @return Gets <code>defaultExtension</code> property
-     */
-    String getDefaultExtension();
-
+public interface PebbleConfiguration extends ViewsRendererConfiguration {
     /**
      * @return Gets <code>cacheActive</code> property
-     */    
+     */
     boolean isCacheActive();
 
     /**
      * @return Gets <code>newLineTrimming</code> property
-     */    
+     */
     boolean isNewLineTrimming();
 
    /**
@@ -52,26 +47,26 @@ public interface PebbleConfiguration extends Toggleable {
 
     /**
      * @return Gets <code>strictVariables</code> property
-     */    
+     */
     boolean isStrictVariables();
 
     /**
      * @return Gets <code>greedyMatchMethod</code> property
-     */    
+     */
     boolean isGreedyMatchMethod();
 
     /**
      * @return Gets <code>isAllowOverrideCoreOperators</code> property
-     */    
+     */
     boolean isAllowOverrideCoreOperators();
 
         /**
      * @return Gets <code>literalDecimalsAsInteger</code> property
-     */    
+     */
     boolean isLiteralDecimalsAsIntegers();
 
     /**
      * @return Gets <code>literalNumbersAsBigDecimals</code> property
-     */    
+     */
     boolean isLiteralNumbersAsBigDecimals();
 }

--- a/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleConfigurationProperties.java
+++ b/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleConfigurationProperties.java
@@ -20,6 +20,7 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.views.ViewsConfigurationProperties;
 import io.pebbletemplates.pebble.extension.escaper.EscapeFilter;
 import jakarta.inject.Named;
+import org.jspecify.annotations.Nullable;
 
 /**
  * {@link ConfigurationProperties} implementation of {@link PebbleConfiguration}.
@@ -73,7 +74,7 @@ public class PebbleConfigurationProperties implements PebbleConfiguration {
     }
 
     @Override
-    public String getDefaultExtension() {
+    public @Nullable String getDefaultExtension() {
         return defaultExtension;
     }
 

--- a/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleConfigurationProperties.java
+++ b/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleConfigurationProperties.java
@@ -28,7 +28,7 @@ import org.jspecify.annotations.Nullable;
  * @author Ecmel Ercan
  * @since 2.2.0
  */
-@Named("Pebble")
+@Named("pebble")
 @ConfigurationProperties(PebbleConfigurationProperties.PREFIX)
 public class PebbleConfigurationProperties implements PebbleConfiguration {
 

--- a/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleConfigurationProperties.java
+++ b/views-pebble/src/main/java/io/micronaut/views/pebble/PebbleConfigurationProperties.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.views.ViewsConfigurationProperties;
 import io.pebbletemplates.pebble.extension.escaper.EscapeFilter;
+import jakarta.inject.Named;
 
 /**
  * {@link ConfigurationProperties} implementation of {@link PebbleConfiguration}.
@@ -26,6 +27,7 @@ import io.pebbletemplates.pebble.extension.escaper.EscapeFilter;
  * @author Ecmel Ercan
  * @since 2.2.0
  */
+@Named("Pebble")
 @ConfigurationProperties(PebbleConfigurationProperties.PREFIX)
 public class PebbleConfigurationProperties implements PebbleConfiguration {
 

--- a/views-pebble/src/test/java/io/micronaut/views/pebble/PebbleViewsRendererConfigurationTest.java
+++ b/views-pebble/src/test/java/io/micronaut/views/pebble/PebbleViewsRendererConfigurationTest.java
@@ -1,0 +1,20 @@
+package io.micronaut.views.pebble;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.views.ViewsRendererConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class PebbleViewsRendererConfigurationTest {
+
+    @Test
+    void testNamedViewRendererConfiguration() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ViewsRendererConfiguration configuration = context.getBean(ViewsRendererConfiguration.class, Qualifiers.byName("pebble"));
+
+            assertInstanceOf(PebbleConfiguration.class, configuration);
+        }
+    }
+}

--- a/views-rocker/build.gradle
+++ b/views-rocker/build.gradle
@@ -32,4 +32,8 @@ dependencies {
     testImplementation(mn.micronaut.management)
     testImplementation(mnValidation.micronaut.validation)
     testImplementation(mn.snakeyaml)
+
+    testImplementation(mnTest.junit.jupiter.api)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
 }

--- a/views-rocker/src/main/java/io/micronaut/views/rocker/RockerViewsRendererConfigurationProperties.java
+++ b/views-rocker/src/main/java/io/micronaut/views/rocker/RockerViewsRendererConfigurationProperties.java
@@ -17,6 +17,7 @@ package io.micronaut.views.rocker;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.views.ViewsConfigurationProperties;
+import jakarta.inject.Named;
 
 /**
  * {@link ConfigurationProperties} implementation of {@link RockerViewsRendererConfiguration}.
@@ -24,6 +25,7 @@ import io.micronaut.views.ViewsConfigurationProperties;
  * @author Sam Adams
  * @since 1.3.2
  */
+@Named("rocker")
 @ConfigurationProperties(RockerViewsRendererConfigurationProperties.PREFIX)
 public class RockerViewsRendererConfigurationProperties implements RockerViewsRendererConfiguration {
 

--- a/views-rocker/src/main/java/io/micronaut/views/rocker/RockerViewsRendererConfigurationProperties.java
+++ b/views-rocker/src/main/java/io/micronaut/views/rocker/RockerViewsRendererConfigurationProperties.java
@@ -18,6 +18,7 @@ package io.micronaut.views.rocker;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.views.ViewsConfigurationProperties;
 import jakarta.inject.Named;
+import org.jspecify.annotations.Nullable;
 
 /**
  * {@link ConfigurationProperties} implementation of {@link RockerViewsRendererConfiguration}.
@@ -76,7 +77,7 @@ public class RockerViewsRendererConfigurationProperties implements RockerViewsRe
      * @return Default extension for templates. By default {@value #DEFAULT_EXTENSION}.
      */
     @Override
-    public String getDefaultExtension() {
+    public @Nullable String getDefaultExtension() {
         return defaultExtension;
     }
 

--- a/views-rocker/src/test/java/io/micronaut/views/rocker/RockerViewsRendererConfigurationTest.java
+++ b/views-rocker/src/test/java/io/micronaut/views/rocker/RockerViewsRendererConfigurationTest.java
@@ -1,0 +1,20 @@
+package io.micronaut.views.rocker;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.views.ViewsRendererConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class RockerViewsRendererConfigurationTest {
+
+    @Test
+    void testNamedViewRendererConfiguration() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ViewsRendererConfiguration configuration = context.getBean(ViewsRendererConfiguration.class, Qualifiers.byName("rocker"));
+
+            assertInstanceOf(RockerViewsRendererConfiguration.class, configuration);
+        }
+    }
+}

--- a/views-velocity/build.gradle
+++ b/views-velocity/build.gradle
@@ -31,4 +31,8 @@ dependencies {
     testImplementation(mn.micronaut.management)
     testImplementation(mnValidation.micronaut.validation)
     testImplementation(mn.snakeyaml)
+
+    testImplementation(mnTest.junit.jupiter.api)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
 }

--- a/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRendererConfiguration.java
+++ b/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRendererConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.views.velocity;
 
-import io.micronaut.core.util.Toggleable;
+import io.micronaut.views.ViewsRendererConfiguration;
 
 /**
  * Configuration for {@link VelocityViewsRenderer}.
@@ -23,10 +23,5 @@ import io.micronaut.core.util.Toggleable;
  * @author Sergio del Amo
  * @since 1.0
  */
-public interface VelocityViewsRendererConfiguration extends Toggleable {
-
-    /**
-     * @return Default extension for templates
-     */
-    String getDefaultExtension();
+public interface VelocityViewsRendererConfiguration extends ViewsRendererConfiguration {
 }

--- a/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRendererConfigurationProperties.java
+++ b/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRendererConfigurationProperties.java
@@ -18,6 +18,7 @@ package io.micronaut.views.velocity;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.views.ViewsConfigurationProperties;
 import jakarta.inject.Named;
+import org.jspecify.annotations.Nullable;
 
 /**
  * {@link ConfigurationProperties} implementation of {@link VelocityViewsRendererConfiguration}.
@@ -63,7 +64,7 @@ public class VelocityViewsRendererConfigurationProperties implements VelocityVie
      * @return Default extension for templates. By default {@value #DEFAULT_EXTENSION}.
      */
     @Override
-    public String getDefaultExtension() {
+    public @Nullable String getDefaultExtension() {
         return defaultExtension;
     }
 

--- a/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRendererConfigurationProperties.java
+++ b/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRendererConfigurationProperties.java
@@ -17,6 +17,7 @@ package io.micronaut.views.velocity;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.views.ViewsConfigurationProperties;
+import jakarta.inject.Named;
 
 /**
  * {@link ConfigurationProperties} implementation of {@link VelocityViewsRendererConfiguration}.
@@ -24,6 +25,7 @@ import io.micronaut.views.ViewsConfigurationProperties;
  * @author Sergio del Amo
  * @since 1.0
  */
+@Named("velocity")
 @ConfigurationProperties(VelocityViewsRendererConfigurationProperties.PREFIX)
 public class VelocityViewsRendererConfigurationProperties implements VelocityViewsRendererConfiguration {
 

--- a/views-velocity/src/test/java/io/micronaut/views/velocity/VelocityViewsRendererConfigurationTest.java
+++ b/views-velocity/src/test/java/io/micronaut/views/velocity/VelocityViewsRendererConfigurationTest.java
@@ -1,0 +1,20 @@
+package io.micronaut.views.velocity;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.views.ViewsRendererConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class VelocityViewsRendererConfigurationTest {
+
+    @Test
+    void testNamedViewRendererConfiguration() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ViewsRendererConfiguration configuration = context.getBean(ViewsRendererConfiguration.class, Qualifiers.byName("velocity"));
+
+            assertInstanceOf(VelocityViewsRendererConfiguration.class, configuration);
+        }
+    }
+}


### PR DESCRIPTION
Introduce a common ViewsRendererConfiguration interface in views-core for renderer enablement and default template extension settings.

Update Freemarker, Handlebars, Pebble, Rocker, and Velocity renderer configuration interfaces to extend the shared contract instead of duplicating Toggleable and getDefaultExtension declarations.