### PR TITLE
  Consolidate shared view path resolution in AbstractViewsRenderer

### DIFF
--- a/views-core/src/main/java/io/micronaut/views/AbstractViewsRenderer.java
+++ b/views-core/src/main/java/io/micronaut/views/AbstractViewsRenderer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.views;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.ResourceLoader;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Base class for view renderers that use a {@link ViewsRendererConfiguration}.
+ *
+ * @param <T> The model type
+ * @param <R> The request type
+ */
+@Internal
+public abstract class AbstractViewsRenderer<T, R> implements ViewsRenderer<T, R> {
+
+    private final ViewsRendererConfiguration configuration;
+    private final @Nullable ResourceLoader resourceLoader;
+    private final String folder;
+
+    /**
+     * @param configuration Renderer configuration
+     * @param folder The template folder
+     */
+    protected AbstractViewsRenderer(@NonNull ViewsRendererConfiguration configuration,
+                                    @NonNull String folder) {
+        this(configuration, folder, null);
+    }
+
+    /**
+     * @param configuration Renderer configuration
+     * @param folder The template folder
+     * @param resourceLoader The template resource loader
+     */
+    protected AbstractViewsRenderer(@NonNull ViewsRendererConfiguration configuration,
+                                    @NonNull String folder,
+                                    @Nullable ResourceLoader resourceLoader) {
+        this.configuration = configuration;
+        this.folder = folder;
+        this.resourceLoader = resourceLoader;
+    }
+
+    @NonNull
+    protected final String defaultExtension() {
+        return configuration.getDefaultExtension();
+    }
+
+    /**
+     * Normalizes a view name and appends the configured default extension.
+     *
+     * @param name The requested view name
+     * @return The template name
+     */
+    @NonNull
+    protected final String viewNameWithExtension(@NonNull String name) {
+        String extension = defaultExtension();
+        return ViewUtils.normalizeFile(name, extension) + ViewUtils.EXTENSION_SEPARATOR + extension;
+    }
+
+    /**
+     * Normalizes a view name relative to a template folder without appending its extension.
+     *
+     * @param name The requested view name
+     * @return The template location
+     */
+    @NonNull
+    protected final String viewLocationWithoutExtension(@NonNull String name) {
+        return folder + ViewUtils.normalizeFile(name, defaultExtension());
+    }
+
+    /**
+     * Normalizes a view name relative to a template folder and appends the configured default extension.
+     *
+     * @param name The requested view name
+     * @return The template path
+     */
+    @NonNull
+    protected final String viewLocationWithExtension(@NonNull String name) {
+        return folder + viewNameWithExtension(name);
+    }
+
+    @Override
+    public boolean exists(@NonNull String viewName) {
+        return viewName != null && resourceLoader != null && resourceLoader.getResource(folder + viewNameWithExtension(viewName)).isPresent();
+    }
+}

--- a/views-core/src/main/java/io/micronaut/views/AbstractViewsRenderer.java
+++ b/views-core/src/main/java/io/micronaut/views/AbstractViewsRenderer.java
@@ -55,8 +55,7 @@ public abstract class AbstractViewsRenderer<T, R> implements ViewsRenderer<T, R>
         this.resourceLoader = resourceLoader;
     }
 
-    @NonNull
-    protected final String defaultExtension() {
+    protected final @Nullable String defaultExtension() {
         return configuration.getDefaultExtension();
     }
 

--- a/views-core/src/main/java/io/micronaut/views/AbstractViewsRenderer.java
+++ b/views-core/src/main/java/io/micronaut/views/AbstractViewsRenderer.java
@@ -20,6 +20,8 @@ import io.micronaut.core.io.ResourceLoader;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Objects;
+
 /**
  * Base class for view renderers that use a {@link ViewsRendererConfiguration}.
  *
@@ -55,8 +57,8 @@ public abstract class AbstractViewsRenderer<T, R> implements ViewsRenderer<T, R>
         this.resourceLoader = resourceLoader;
     }
 
-    protected final @Nullable String defaultExtension() {
-        return configuration.getDefaultExtension();
+    protected final @NonNull String defaultExtension() {
+        return Objects.requireNonNull(configuration.getDefaultExtension(), "defaultExtension");
     }
 
     /**
@@ -68,7 +70,10 @@ public abstract class AbstractViewsRenderer<T, R> implements ViewsRenderer<T, R>
     @NonNull
     protected final String viewNameWithExtension(@NonNull String name) {
         String extension = defaultExtension();
-        return ViewUtils.normalizeFile(name, extension) + ViewUtils.EXTENSION_SEPARATOR + extension;
+        String extensionWithoutSeparator = extension.startsWith(ViewUtils.EXTENSION_SEPARATOR)
+            ? extension.substring(ViewUtils.EXTENSION_SEPARATOR.length())
+            : extension;
+        return ViewUtils.normalizeFile(name, extension) + ViewUtils.EXTENSION_SEPARATOR + extensionWithoutSeparator;
     }
 
     /**

--- a/views-core/src/main/java/io/micronaut/views/AbstractViewsRenderer.java
+++ b/views-core/src/main/java/io/micronaut/views/AbstractViewsRenderer.java
@@ -100,6 +100,6 @@ public abstract class AbstractViewsRenderer<T, R> implements ViewsRenderer<T, R>
 
     @Override
     public boolean exists(@NonNull String viewName) {
-        return viewName != null && resourceLoader != null && resourceLoader.getResource(folder + viewNameWithExtension(viewName)).isPresent();
+        return resourceLoader != null && resourceLoader.getResource(folder + viewNameWithExtension(Objects.requireNonNull(viewName))).isPresent();
     }
 }

--- a/views-core/src/test/java/io/micronaut/views/AbstractViewsRendererTest.java
+++ b/views-core/src/test/java/io/micronaut/views/AbstractViewsRendererTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.views;
+
+import io.micronaut.core.io.ResourceLoader;
+import io.micronaut.core.io.Writable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbstractViewsRendererTest {
+
+    @Test
+    void viewHelpersSupportConfiguredExtensionsWithAndWithoutLeadingDot() {
+        assertViewHelpers("html");
+        assertViewHelpers(".html");
+    }
+
+    @Test
+    void existsUsesTheConfiguredFolderAndExtension() {
+        TestViewsRenderer renderer = new TestViewsRenderer("html", new TestResourceLoader(Set.of("views/home.html")));
+
+        assertTrue(renderer.exists("home"));
+        assertFalse(renderer.exists("missing"));
+    }
+
+    @Test
+    void viewHelpersFailWhenTheDefaultExtensionIsNull() {
+        TestViewsRenderer renderer = new TestViewsRenderer(null, new TestResourceLoader(Set.of()));
+
+        assertThrows(NullPointerException.class, () -> renderer.viewNameWithExtension("home"));
+        assertThrows(NullPointerException.class, () -> renderer.viewLocationWithoutExtension("home"));
+        assertThrows(NullPointerException.class, () -> renderer.viewLocationWithExtension("home"));
+        assertThrows(NullPointerException.class, () -> renderer.exists("home"));
+    }
+
+    private static void assertViewHelpers(String extension) {
+        TestViewsRenderer renderer = new TestViewsRenderer(extension, new TestResourceLoader(Set.of()));
+
+        assertEquals("home.html", renderer.viewNameWithExtension("home"));
+        assertEquals("home.html", renderer.viewNameWithExtension("home.html"));
+        assertEquals("views/home", renderer.viewLocationWithoutExtension("home"));
+        assertEquals("views/home", renderer.viewLocationWithoutExtension("home.html"));
+        assertEquals("views/home.html", renderer.viewLocationWithExtension("home"));
+        assertEquals("views/home.html", renderer.viewLocationWithExtension("home.html"));
+    }
+
+    private static final class TestViewsRenderer extends AbstractViewsRenderer<Object, Object> {
+
+        private TestViewsRenderer(@Nullable String extension, @NonNull ResourceLoader resourceLoader) {
+            super(new TestViewsRendererConfiguration(extension), "views/", resourceLoader);
+        }
+
+        @Override
+        public @NonNull Writable render(@NonNull String viewName, @Nullable Object data, @Nullable Object request) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private record TestViewsRendererConfiguration(@Nullable String extension) implements ViewsRendererConfiguration {
+
+        @Override
+        public @Nullable String getDefaultExtension() {
+            return extension;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return true;
+        }
+    }
+
+    private record TestResourceLoader(Set<String> resourcePaths) implements ResourceLoader {
+
+        @Override
+        public Optional<InputStream> getResourceAsStream(String path) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<URL> getResource(String path) {
+            return resourcePaths.contains(path) ? Optional.of(resourceUrl()) : Optional.empty();
+        }
+
+        @Override
+        public Stream<URL> getResources(String name) {
+            return Stream.empty();
+        }
+
+        @Override
+        public boolean supportsPrefix(String path) {
+            return false;
+        }
+
+        @Override
+        public ResourceLoader forBase(String basePath) {
+            return this;
+        }
+
+        private static URL resourceUrl() {
+            try {
+                return new URL("file:/template");
+            } catch (MalformedURLException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+}

--- a/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
+++ b/views-freemarker/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
@@ -23,9 +23,9 @@ import freemarker.template.TemplateException;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.io.Writable;
 import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.views.AbstractViewsRenderer;
 import io.micronaut.views.ViewUtils;
 import io.micronaut.views.ViewsConfiguration;
-import io.micronaut.views.ViewsRenderer;
 import io.micronaut.views.exceptions.ViewRenderingException;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -46,7 +46,7 @@ import java.io.IOException;
 @Requires(property = FreemarkerViewsRendererConfigurationProperties.PREFIX + ".enabled", notEquals = "false")
 @Requires(classes = Configuration.class)
 @Singleton
-public class FreemarkerViewsRenderer<T, R> implements ViewsRenderer<T, R> {
+public class FreemarkerViewsRenderer<T, R> extends AbstractViewsRenderer<T, R> {
 
     /**
      * Views Configuration.
@@ -70,6 +70,7 @@ public class FreemarkerViewsRenderer<T, R> implements ViewsRenderer<T, R> {
     @Inject
     public FreemarkerViewsRenderer(ViewsConfiguration viewsConfiguration,
                                    FreemarkerViewsRendererConfigurationProperties freemarkerConfiguration) {
+        super(freemarkerConfiguration, viewsConfiguration.getFolder());
         this.viewsConfiguration = viewsConfiguration;
         this.freemarkerMicronautConfiguration = freemarkerConfiguration;
         this.extension = freemarkerConfiguration.getDefaultExtension();
@@ -84,7 +85,7 @@ public class FreemarkerViewsRenderer<T, R> implements ViewsRenderer<T, R> {
         Template template;
         try {
             // this has to fail fast to avoid a ReadTimeoutException from ViewsFilter call
-            template = freemarkerMicronautConfiguration.getTemplate(viewLocation(viewName));
+            template = freemarkerMicronautConfiguration.getTemplate(viewNameWithExtension(viewName));
         } catch (IOException e) {
             throw new ViewRenderingException(
                     "Error rendering Freemarker view [" + viewName + "]: " + e.getMessage(), e);
@@ -102,7 +103,7 @@ public class FreemarkerViewsRenderer<T, R> implements ViewsRenderer<T, R> {
     @Override
     public boolean exists(@NonNull String view) {
         try {
-            freemarkerMicronautConfiguration.getTemplate(viewLocation(view));
+            freemarkerMicronautConfiguration.getTemplate(viewNameWithExtension(view));
         } catch (ParseException | MalformedTemplateNameException e) {
             return true;
         } catch (IOException e) {
@@ -110,11 +111,4 @@ public class FreemarkerViewsRenderer<T, R> implements ViewsRenderer<T, R> {
         }
         return true;
     }
-
-    private String viewLocation(String name) {
-        return ViewUtils.normalizeFile(name, extension) +
-                ViewUtils.EXTENSION_SEPARATOR +
-                extension;
-    }
-
 }

--- a/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRenderer.java
+++ b/views-handlebars/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRenderer.java
@@ -23,9 +23,8 @@ import io.micronaut.core.io.Writable;
 import io.micronaut.core.io.scan.ClassPathResourceLoader;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.util.ArgumentUtils;
-import io.micronaut.views.ViewUtils;
+import io.micronaut.views.AbstractViewsRenderer;
 import io.micronaut.views.ViewsConfiguration;
-import io.micronaut.views.ViewsRenderer;
 import io.micronaut.views.exceptions.ViewRenderingException;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -46,13 +45,12 @@ import java.io.IOException;
 @Requires(property = HandlebarsViewsRendererConfigurationProperties.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
 @Requires(classes = Handlebars.class)
 @Singleton
-public class HandlebarsViewsRenderer<T, R> implements ViewsRenderer<T, R> {
+public class HandlebarsViewsRenderer<T, R> extends AbstractViewsRenderer<T, R> {
 
     protected final ViewsConfiguration viewsConfiguration;
     protected final ResourceLoader resourceLoader;
     protected HandlebarsViewsRendererConfiguration handlebarsViewsRendererConfiguration;
     protected Handlebars handlebars;
-    protected String folder;
 
     /**
      * @param viewsConfiguration                   Views Configuration
@@ -65,10 +63,10 @@ public class HandlebarsViewsRenderer<T, R> implements ViewsRenderer<T, R> {
                                    ClassPathResourceLoader resourceLoader,
                                    HandlebarsViewsRendererConfiguration handlebarsViewsRendererConfiguration,
                                    Handlebars handlebars) {
+        super(handlebarsViewsRendererConfiguration, viewsConfiguration.getFolder(), resourceLoader);
         this.viewsConfiguration = viewsConfiguration;
         this.resourceLoader = resourceLoader;
         this.handlebarsViewsRendererConfiguration = handlebarsViewsRendererConfiguration;
-        this.folder = viewsConfiguration.getFolder();
         this.handlebars = handlebars;
     }
 
@@ -78,7 +76,7 @@ public class HandlebarsViewsRenderer<T, R> implements ViewsRenderer<T, R> {
                            @Nullable T data,
                            @Nullable R request) {
         ArgumentUtils.requireNonNull("viewName", viewName);
-        String location = viewLocation(viewName);
+        String location = viewLocationWithoutExtension(viewName);
         Template template;
         try {
             template = handlebars.compile(location);
@@ -94,21 +92,4 @@ public class HandlebarsViewsRenderer<T, R> implements ViewsRenderer<T, R> {
         };
     }
 
-    @Override
-    public boolean exists(@NonNull String viewName) {
-        //noinspection ConstantConditions
-        if (viewName == null) {
-            return false;
-        }
-        String location = viewLocation(viewName) + ViewUtils.EXTENSION_SEPARATOR + extension();
-        return resourceLoader.getResource(location).isPresent();
-    }
-
-    private String viewLocation(final String name) {
-        return folder + ViewUtils.normalizeFile(name, extension());
-    }
-
-    private String extension() {
-        return handlebarsViewsRendererConfiguration.getDefaultExtension();
-    }
 }

--- a/views-rocker/src/main/java/io/micronaut/views/rocker/RockerViewsRenderer.java
+++ b/views-rocker/src/main/java/io/micronaut/views/rocker/RockerViewsRenderer.java
@@ -18,9 +18,9 @@ package io.micronaut.views.rocker;
 import com.fizzed.rocker.BindableRockerModel;
 import io.micronaut.core.io.Writable;
 import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.views.AbstractViewsRenderer;
 import io.micronaut.views.ViewUtils;
 import io.micronaut.views.ViewsConfiguration;
-import io.micronaut.views.ViewsRenderer;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.jspecify.annotations.NonNull;
@@ -37,12 +37,11 @@ import java.util.Map;
  * @param <R> The request type
  */
 @Singleton
-public class RockerViewsRenderer<T, R> implements ViewsRenderer<T, R> {
+public class RockerViewsRenderer<T, R> extends AbstractViewsRenderer<T, R> {
 
     protected final RockerEngine rockerEngine;
     protected final ViewsConfiguration viewsConfiguration;
     protected final RockerViewsRendererConfiguration rockerConfiguration;
-    protected final String folder;
 
     /**
      * @param viewsConfiguration  Views Configuration
@@ -53,10 +52,10 @@ public class RockerViewsRenderer<T, R> implements ViewsRenderer<T, R> {
     public RockerViewsRenderer(ViewsConfiguration viewsConfiguration,
                                RockerViewsRendererConfiguration rockerConfiguration,
                                RockerEngine rockerEngine) {
+        super(rockerConfiguration, viewsConfiguration.getFolder());
         this.viewsConfiguration = viewsConfiguration;
         this.rockerConfiguration = rockerConfiguration;
         this.rockerEngine = rockerEngine;
-        this.folder = viewsConfiguration.getFolder();
     }
 
     @NonNull

--- a/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRenderer.java
+++ b/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRenderer.java
@@ -17,9 +17,9 @@ package io.micronaut.views.velocity;
 
 import io.micronaut.core.io.Writable;
 import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.views.AbstractViewsRenderer;
 import io.micronaut.views.ViewUtils;
 import io.micronaut.views.ViewsConfiguration;
-import io.micronaut.views.ViewsRenderer;
 import io.micronaut.views.exceptions.ViewRenderingException;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -33,7 +33,6 @@ import jakarta.inject.Singleton;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Properties;
 
 /**
  * Renders with templates with Apache Velocity Project.
@@ -47,12 +46,11 @@ import java.util.Properties;
  * @param <R> The request type
  */
 @Singleton
-public class VelocityViewsRenderer<T, R> implements ViewsRenderer<T, R> {
+public class VelocityViewsRenderer<T, R> extends AbstractViewsRenderer<T, R> {
 
     protected final VelocityEngine velocityEngine;
     protected final ViewsConfiguration viewsConfiguration;
     protected final VelocityViewsRendererConfiguration velocityConfiguration;
-    protected final String folder;
 
     /**
      * @param viewsConfiguration    Views Configuration
@@ -63,10 +61,10 @@ public class VelocityViewsRenderer<T, R> implements ViewsRenderer<T, R> {
     public VelocityViewsRenderer(ViewsConfiguration viewsConfiguration,
                           VelocityViewsRendererConfiguration velocityConfiguration,
                           VelocityEngine velocityEngine) {
+        super(velocityConfiguration, viewsConfiguration.getFolder());
         this.viewsConfiguration = viewsConfiguration;
         this.velocityConfiguration = velocityConfiguration;
         this.velocityEngine = velocityEngine;
-        this.folder = viewsConfiguration.getFolder();
     }
 
     @NonNull
@@ -87,7 +85,7 @@ public class VelocityViewsRenderer<T, R> implements ViewsRenderer<T, R> {
      * @param writer The writer
      */
     public void render(@NonNull String view, VelocityContext context, String encoding, Writer writer) {
-        String viewName = viewName(view);
+        String viewName = viewLocationWithExtension(view);
         try {
             velocityEngine.mergeTemplate(viewName, encoding, context, writer);
         } catch (ResourceNotFoundException | ParseErrorException | MethodInvocationException e) {
@@ -98,31 +96,11 @@ public class VelocityViewsRenderer<T, R> implements ViewsRenderer<T, R> {
     @Override
     public boolean exists(@NonNull String viewName) {
         try {
-            velocityEngine.getTemplate(viewName(viewName));
+            velocityEngine.getTemplate(viewLocationWithExtension(viewName));
         } catch (ResourceNotFoundException | ParseErrorException e) {
             throw new ViewRenderingException("Error rendering Velocity view [" + viewName + "]: " + e.getMessage(), e);
         }
         return true;
     }
 
-    /**
-     * Only used in the deprecated constructor.
-     */
-    private VelocityEngine initializeVelocityEngine() {
-        final Properties p = new Properties();
-        p.setProperty("resource.loaders", "class");
-        p.setProperty("resource.loader.class.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
-        return new VelocityEngine(p);
-    }
-
-    private String viewName(final String name) {
-        return folder +
-                ViewUtils.normalizeFile(name, extension()) +
-                "." +
-                extension();
-    }
-
-    private String extension() {
-        return velocityConfiguration.getDefaultExtension();
-    }
 }

--- a/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRenderer.java
+++ b/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRenderer.java
@@ -97,7 +97,7 @@ public class VelocityViewsRenderer<T, R> extends AbstractViewsRenderer<T, R> {
     public boolean exists(@NonNull String viewName) {
         try {
             velocityEngine.getTemplate(viewLocationWithExtension(viewName));
-        } catch (ResourceNotFoundException e) {
+        } catch (ResourceNotFoundException _) {
             return false;
         } catch (ParseErrorException e) {
             throw new ViewRenderingException("Error rendering Velocity view [" + viewName + "]: " + e.getMessage(), e);

--- a/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRenderer.java
+++ b/views-velocity/src/main/java/io/micronaut/views/velocity/VelocityViewsRenderer.java
@@ -97,7 +97,9 @@ public class VelocityViewsRenderer<T, R> extends AbstractViewsRenderer<T, R> {
     public boolean exists(@NonNull String viewName) {
         try {
             velocityEngine.getTemplate(viewLocationWithExtension(viewName));
-        } catch (ResourceNotFoundException | ParseErrorException e) {
+        } catch (ResourceNotFoundException e) {
+            return false;
+        } catch (ParseErrorException e) {
             throw new ViewRenderingException("Error rendering Velocity view [" + viewName + "]: " + e.getMessage(), e);
         }
         return true;


### PR DESCRIPTION
  Move common renderer configuration, view-name normalization, template location construction, and resource existence checks into
  AbstractViewsRenderer.

  Update the FreeMarker, Handlebars, Rocker, and Velocity renderers to use the shared helpers while preserving each engine’s template-
  resolution semantics.