### PR TITLE
Make React rendering contexts pluggable

### DIFF
--- a/views-react/src/main/java/io/micronaut/views/react/DefaultReactContextProvider.java
+++ b/views-react/src/main/java/io/micronaut/views/react/DefaultReactContextProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.views.react;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.views.react.util.BeanPool;
+import org.graalvm.polyglot.Context;
+
+import java.util.function.Function;
+
+/**
+ * Owns the standalone React context pool used when an application does not supply a
+ * {@link ReactContextProvider}. Source changes invalidate the whole pool because its contexts
+ * belong exclusively to Views React and their module state cannot be reused safely.
+ */
+@Internal
+final class DefaultReactContextProvider implements ReactContextProvider {
+    private final BeanPool<ReactJSContext> contextPool;
+
+    DefaultReactContextProvider(BeanPool<ReactJSContext> contextPool) {
+        this.contextPool = contextPool;
+    }
+
+    @Override
+    public <T> T withContext(Function<Context, T> callback) {
+        return contextPool.useContext(handle -> callback.apply(handle.get().polyglotContext()));
+    }
+
+    @Override
+    public void sourcesChanged(long generation) {
+        contextPool.clear();
+    }
+}

--- a/views-react/src/main/java/io/micronaut/views/react/ReactContextProvider.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactContextProvider.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
  * change.</p>
  *
  * @author Micronaut Team
- * @since 6.4.0
+ * @since 6.3.0
  */
 @Experimental
 @FunctionalInterface

--- a/views-react/src/main/java/io/micronaut/views/react/ReactContextProvider.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactContextProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.views.react;
+
+import io.micronaut.core.annotation.Experimental;
+import org.graalvm.polyglot.Context;
+
+import java.util.function.Function;
+
+/**
+ * Provides callback-scoped access to a context capable of executing JavaScript.
+ *
+ * <p>The callback must not return the context or context-owned values to application code.
+ * Renderer implementations may associate context-bound caches with the context, but providers
+ * retain ownership and providers that do not own their contexts must leave them open when sources
+ * change.</p>
+ *
+ * @author Micronaut Team
+ * @since 6.4.0
+ */
+@Experimental
+@FunctionalInterface
+public interface ReactContextProvider {
+
+    /**
+     * Execute a callback with exclusive access to a context.
+     *
+     * @param callback The callback
+     * @param <T> The callback result type
+     * @return The callback result
+     */
+    <T> T withContext(Function<Context, T> callback);
+
+    /**
+     * Notify the provider that React sources have changed.
+     *
+     * @param generation The new source generation
+     */
+    default void sourcesChanged(long generation) {
+    }
+}

--- a/views-react/src/main/java/io/micronaut/views/react/ReactJSBeanFactory.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactJSBeanFactory.java
@@ -18,7 +18,7 @@ package io.micronaut.views.react;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Prototype;
-import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.views.react.util.BeanPool;
 import io.micronaut.views.react.util.JavaUtilLoggingToSLF4J;
@@ -76,10 +76,9 @@ final class ReactJSBeanFactory {
     }
 
     @Singleton
-    ApplicationEventListener<ReactJSSourcesChangedEvent> poolCleaner(BeanPool<ReactJSContext> contextPool) {
-        // Clearing the pool ensures that new requests go via the pool and from there, back to
-        // createContext() which will in turn then reload the files on disk.
-        return event -> contextPool.clear();
+    @Requires(missingBeans = ReactContextProvider.class)
+    ReactContextProvider reactContextProvider(BeanPool<ReactJSContext> contextPool) {
+        return new DefaultReactContextProvider(contextPool);
     }
 
     @ReactBean
@@ -129,23 +128,7 @@ final class ReactJSBeanFactory {
     ReactJSContext reactJsContext(@ReactBean Context polyglotContext,
                                   ReactViewsRendererConfiguration configuration,
                                   ReactJSSources reactJSSources) {
-
-        Value global = polyglotContext.getBindings("js");
-        Value ssrModule = polyglotContext.eval(reactJSSources.serverBundle());
-
-        // Take all the exports from the components bundle, and expose them to the render script.
-        for (var name : ssrModule.getMemberKeys()) {
-            global.putMember(name, ssrModule.getMember(name));
-        }
-
-        // Evaluate our JS-side framework specific render logic.
-        Value renderModule = polyglotContext.eval(reactJSSources.renderScript());
-        Value render = renderModule.getMember("ssr");
-        if (render == null) {
-            throw new IllegalArgumentException("Unable to look up ssr function in render script `%s`. Please make sure it is exported.".formatted(configuration.getRenderScript()));
-        }
-
-        return new ReactJSContext(polyglotContext, render, ssrModule);
+        return new ReactJSContext(polyglotContext, null, null);
     }
 
 }

--- a/views-react/src/main/java/io/micronaut/views/react/ReactJSBeanFactory.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactJSBeanFactory.java
@@ -28,7 +28,6 @@ import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.SandboxPolicy;
-import org.graalvm.polyglot.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -125,10 +124,8 @@ final class ReactJSBeanFactory {
     }
 
     @Prototype
-    ReactJSContext reactJsContext(@ReactBean Context polyglotContext,
-                                  ReactViewsRendererConfiguration configuration,
-                                  ReactJSSources reactJSSources) {
-        return new ReactJSContext(polyglotContext, null, null);
+    ReactJSContext reactJsContext(@ReactBean Context polyglotContext) {
+        return new ReactJSContext(polyglotContext);
     }
 
 }

--- a/views-react/src/main/java/io/micronaut/views/react/ReactJSContext.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactJSContext.java
@@ -17,29 +17,14 @@ package io.micronaut.views.react;
 
 import jakarta.annotation.PreDestroy;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Value;
-
-import java.util.List;
 
 /**
  * A bean that handles the Javascript {@link Context} object representing a loaded execution
  * environment usable by one thread at a time.
  *
  * @param polyglotContext A single-threaded Javascript language context (global vars etc).
- * @param render The {@code ssr} function defined in Javascript.
- * @param ssrModule The JS module containing the user's React components.
  */
-record ReactJSContext(Context polyglotContext,
-                      Value render,
-                      Value ssrModule) implements AutoCloseable {
-    // Symbols the user's server side bundle might supply us with.
-    private static final List<String> IMPORT_SYMBOLS = List.of("React", "ReactDOMServer", "renderToString", "h");
-
-    boolean moduleHasMember(String memberName) {
-        assert !IMPORT_SYMBOLS.contains(memberName) : "Should not query the server-side bundle for member name " + memberName;
-        return ssrModule.hasMember(memberName);
-    }
-
+record ReactJSContext(Context polyglotContext) implements AutoCloseable {
     @PreDestroy
     @Override
     public void close() {

--- a/views-react/src/main/java/io/micronaut/views/react/ReactJSSources.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactJSSources.java
@@ -50,6 +50,7 @@ class ReactJSSources implements ApplicationEventListener<FileChangedEvent> {
     // to be singleton beans so we can recreate them on file change.
     private Source serverBundle;  // L(this)
     private Source renderScript;  // L(this)
+    private long generation;
 
     ReactJSSources(ResourceResolver resourceResolver,
                    ReactViewsRendererConfiguration reactViewsRendererConfiguration,
@@ -73,7 +74,11 @@ class ReactJSSources implements ApplicationEventListener<FileChangedEvent> {
         return renderScript;
     }
 
-    private static Source loadSource(ResourceResolver resolver, String desiredPath, String propName) {
+    synchronized long generation() {
+        return generation;
+    }
+
+    private Source loadSource(ResourceResolver resolver, String desiredPath, String propName) {
         try {
             Optional<URL> sourceURL = resolver.getResource(desiredPath);
             if (sourceURL.isEmpty()) {
@@ -82,8 +87,9 @@ class ReactJSSources implements ApplicationEventListener<FileChangedEvent> {
             URL url = sourceURL.get();
             try (var reader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)) {
                 String path = url.getPath();
-                var fileName = path.substring(path.lastIndexOf('/') + 1);
-                Source.Builder sourceBuilder = Source.newBuilder("js", reader, fileName);
+                var fileName = path.substring(path.lastIndexOf('/') + 1) + "?mn-react-generation=" + generation;
+                Source.Builder sourceBuilder = Source.newBuilder("js", reader, fileName)
+                    .uri(java.net.URI.create(url.toString()));
                 return sourceBuilder.mimeType("application/javascript+module").build();
             }
         } catch (IOException e) {
@@ -98,10 +104,10 @@ class ReactJSSources implements ApplicationEventListener<FileChangedEvent> {
         }
 
         var path = event.getPath().toAbsolutePath();
-        if (path.equals(Paths.get(serverBundle.getPath()).toAbsolutePath())) {
+        if (serverBundle != null && path.equals(Paths.get(serverBundle.getPath()).toAbsolutePath())) {
             serverBundle = null;
         }
-        if (path.equals(Paths.get(renderScript.getPath()).toAbsolutePath())) {
+        if (renderScript != null && path.equals(Paths.get(renderScript.getPath()).toAbsolutePath())) {
             renderScript = null;
         }
 
@@ -109,7 +115,8 @@ class ReactJSSources implements ApplicationEventListener<FileChangedEvent> {
             return;
         }
 
+        generation++;
         LOG.info("Reloaded React SSR bundle due to file change.");
-        sourcesChangedEventPublisher.publishEvent(new ReactJSSourcesChangedEvent(this));
+        sourcesChangedEventPublisher.publishEvent(new ReactJSSourcesChangedEvent(this, generation));
     }
 }

--- a/views-react/src/main/java/io/micronaut/views/react/ReactJSSources.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactJSSources.java
@@ -30,6 +30,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -104,10 +105,10 @@ class ReactJSSources implements ApplicationEventListener<FileChangedEvent> {
         }
 
         var path = event.getPath().toAbsolutePath();
-        if (serverBundle != null && path.equals(Paths.get(serverBundle.getPath()).toAbsolutePath())) {
+        if (serverBundle != null && path.equals(sourcePath(serverBundle))) {
             serverBundle = null;
         }
-        if (renderScript != null && path.equals(Paths.get(renderScript.getPath()).toAbsolutePath())) {
+        if (renderScript != null && path.equals(sourcePath(renderScript))) {
             renderScript = null;
         }
 
@@ -118,5 +119,9 @@ class ReactJSSources implements ApplicationEventListener<FileChangedEvent> {
         generation++;
         LOG.info("Reloaded React SSR bundle due to file change.");
         sourcesChangedEventPublisher.publishEvent(new ReactJSSourcesChangedEvent(this, generation));
+    }
+
+    private static Path sourcePath(Source source) {
+        return Paths.get(source.getURI()).toAbsolutePath();
     }
 }

--- a/views-react/src/main/java/io/micronaut/views/react/ReactJSSourcesChangedEvent.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactJSSourcesChangedEvent.java
@@ -23,9 +23,25 @@ import io.micronaut.context.event.ApplicationEvent;
  * @author Denis Stepanov
  */
 final class ReactJSSourcesChangedEvent extends ApplicationEvent {
+    private final long generation;
 
-    public ReactJSSourcesChangedEvent(ReactJSSources source) {
+    /**
+     * Records the source generation in the event so context providers can invalidate their
+     * context-bound module state without assuming that a source change permits closing a context.
+     *
+     * @param source The source manager that detected the change
+     * @param generation The newly active source generation
+     */
+    public ReactJSSourcesChangedEvent(ReactJSSources source, long generation) {
         super(source);
+        this.generation = generation;
+    }
+
+    /**
+     * @return The source generation active after the change
+     */
+    long generation() {
+        return generation;
     }
 
 }

--- a/views-react/src/main/java/io/micronaut/views/react/ReactViewsRenderer.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactViewsRenderer.java
@@ -16,13 +16,14 @@
 package io.micronaut.views.react;
 
 import io.micronaut.context.exceptions.BeanInstantiationException;
+import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.core.io.Writable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.exceptions.MessageBodyException;
 import io.micronaut.views.ViewsRenderer;
 import io.micronaut.views.react.truffle.IntrospectableToTruffleAdapter;
-import io.micronaut.views.react.util.BeanPool;
 import jakarta.inject.Singleton;
+import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.Value;
 import org.jspecify.annotations.NonNull;
@@ -31,6 +32,8 @@ import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * <p>Instantiates GraalJS and uses it to render React components server side. See the user guide
@@ -39,13 +42,18 @@ import java.nio.charset.StandardCharsets;
  * @param <PROPS> An introspectable bean type that will be fed to the ReactJS root component as props.
  */
 @Singleton
-class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpRequest<?>> {
-    private final BeanPool<ReactJSContext> beanPool;
+class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpRequest<?>>, ApplicationEventListener<ReactJSSourcesChangedEvent> {
+    private final ReactContextProvider contextProvider;
     private final ReactViewsRendererConfiguration reactViewsRendererConfiguration;
+    private final ReactJSSources reactJSSources;
+    private final Map<Context, LoadedReactContext> loadedContexts = new WeakHashMap<>();
 
-    ReactViewsRenderer(BeanPool<ReactJSContext> beanPool, ReactViewsRendererConfiguration reactViewsRendererConfiguration) {
-        this.beanPool = beanPool;
+    ReactViewsRenderer(ReactContextProvider contextProvider,
+                       ReactViewsRendererConfiguration reactViewsRendererConfiguration,
+                       ReactJSSources reactJSSources) {
+        this.contextProvider = contextProvider;
         this.reactViewsRendererConfiguration = reactViewsRendererConfiguration;
+        this.reactJSSources = reactJSSources;
     }
 
     /**
@@ -61,8 +69,8 @@ class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpRequest<?>> 
     public @NonNull Writable render(@NonNull String viewName, @Nullable PROPS props, @Nullable HttpRequest<?> request) {
         return writer -> {
             try {
-                beanPool.useContext(handle -> {
-                    render(viewName, props, writer, handle.get(), request);
+                contextProvider.withContext(context -> {
+                    render(viewName, props, writer, loaded(context), request);
                     return null;
                 });
             } catch (BeanInstantiationException e) {
@@ -76,10 +84,42 @@ class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpRequest<?>> 
 
     @Override
     public boolean exists(@NonNull String viewName) {
-        return beanPool.useContext(handle -> handle.get().moduleHasMember(viewName));
+        return contextProvider.withContext(context -> loaded(context).moduleHasMember(viewName));
     }
 
-    private void render(String componentName, PROPS props, Writer writer, ReactJSContext context, @Nullable HttpRequest<?> request) {
+    @Override
+    public void onApplicationEvent(ReactJSSourcesChangedEvent event) {
+        long generation = event.generation();
+        synchronized (loadedContexts) {
+            loadedContexts.clear();
+        }
+        contextProvider.sourcesChanged(generation);
+    }
+
+    private LoadedReactContext loaded(Context context) {
+        long generation = reactJSSources.generation();
+        synchronized (loadedContexts) {
+            LoadedReactContext loaded = loadedContexts.get(context);
+            if (loaded == null || loaded.generation() != generation) {
+                Value global = context.getBindings("js");
+                Value ssrModule = context.eval(reactJSSources.serverBundle());
+                for (String name : ssrModule.getMemberKeys()) {
+                    global.putMember(name, ssrModule.getMember(name));
+                }
+                Value renderModule = context.eval(reactJSSources.renderScript());
+                Value render = renderModule.getMember("ssr");
+                if (render == null) {
+                    throw new IllegalArgumentException("Unable to look up ssr function in render script `%s`. Please make sure it is exported."
+                        .formatted(reactViewsRendererConfiguration.getRenderScript()));
+                }
+                loaded = new LoadedReactContext(generation, context, render, ssrModule);
+                loadedContexts.put(context, loaded);
+            }
+            return loaded;
+        }
+    }
+
+    private void render(String componentName, PROPS props, Writer writer, LoadedReactContext context, @Nullable HttpRequest<?> request) {
         Value component = context.ssrModule().getMember(componentName);
         if (component == null) {
             throw new IllegalArgumentException("Component name %s wasn't exported from the SSR module.".formatted(componentName));
@@ -92,6 +132,19 @@ class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpRequest<?>> 
         // might also be faster.
         Value guestProps = IntrospectableToTruffleAdapter.wrap(context.polyglotContext(), props);
         context.render().executeVoid(component, guestProps, renderCallback, reactViewsRendererConfiguration.getClientBundleURL(), request);
+    }
+
+    private record LoadedReactContext(long generation,
+                                      Context polyglotContext,
+                                      Value render,
+                                      Value ssrModule) {
+        private static final java.util.Set<String> IMPORT_SYMBOLS =
+            java.util.Set.of("React", "ReactDOMServer", "renderToString", "h");
+
+        boolean moduleHasMember(String memberName) {
+            assert !IMPORT_SYMBOLS.contains(memberName);
+            return ssrModule.hasMember(memberName);
+        }
     }
 
 

--- a/views-react/src/main/java/io/micronaut/views/react/ReactViewsRenderer.java
+++ b/views-react/src/main/java/io/micronaut/views/react/ReactViewsRenderer.java
@@ -70,7 +70,8 @@ class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpRequest<?>>,
         return writer -> {
             try {
                 contextProvider.withContext(context -> {
-                    render(viewName, props, writer, loaded(context), request);
+                    LoadedReactContext loaded = loaded(context);
+                    render(viewName, props, writer, context, loaded, request);
                     return null;
                 });
             } catch (BeanInstantiationException e) {
@@ -112,14 +113,15 @@ class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpRequest<?>>,
                     throw new IllegalArgumentException("Unable to look up ssr function in render script `%s`. Please make sure it is exported."
                         .formatted(reactViewsRendererConfiguration.getRenderScript()));
                 }
-                loaded = new LoadedReactContext(generation, context, render, ssrModule);
+                loaded = new LoadedReactContext(generation, render, ssrModule);
                 loadedContexts.put(context, loaded);
             }
             return loaded;
         }
     }
 
-    private void render(String componentName, PROPS props, Writer writer, LoadedReactContext context, @Nullable HttpRequest<?> request) {
+    private void render(String componentName, PROPS props, Writer writer, Context polyglotContext,
+                        LoadedReactContext context, @Nullable HttpRequest<?> request) {
         Value component = context.ssrModule().getMember(componentName);
         if (component == null) {
             throw new IllegalArgumentException("Component name %s wasn't exported from the SSR module.".formatted(componentName));
@@ -130,12 +132,11 @@ class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpRequest<?>>,
         // We wrap the props object so we can use Micronaut's compile-time reflection implementation.
         // This should be more native-image friendly (no need to write reflection config files), and
         // might also be faster.
-        Value guestProps = IntrospectableToTruffleAdapter.wrap(context.polyglotContext(), props);
+        Value guestProps = IntrospectableToTruffleAdapter.wrap(polyglotContext, props);
         context.render().executeVoid(component, guestProps, renderCallback, reactViewsRendererConfiguration.getClientBundleURL(), request);
     }
 
     private record LoadedReactContext(long generation,
-                                      Context polyglotContext,
                                       Value render,
                                       Value ssrModule) {
         private static final java.util.Set<String> IMPORT_SYMBOLS =
@@ -155,7 +156,6 @@ class ReactViewsRenderer<PROPS> implements ViewsRenderer<PROPS, HttpRequest<?>>,
      * WARNING: These methods may be invoked by sandboxed code. Treat calls adversarially and
      * mark methods with @HostAccess.Export to ensure they're visible inside the sandbox.
      *
-     * @hidden
      */
     public static final class RenderCallback {
         private final Writer responseWriter;

--- a/views-react/src/main/java/io/micronaut/views/react/util/BeanPool.java
+++ b/views-react/src/main/java/io/micronaut/views/react/util/BeanPool.java
@@ -50,7 +50,7 @@ import java.util.function.Supplier;
  */
 @Internal
 public class BeanPool<T> {
-    // TODO: Use @Scheduled to occasionally clear out beans that weren't accessed for a while to recover from traffic spikes.
+    // A future enhancement could periodically clear beans that were not accessed recently.
 
     private final Supplier<T> factory;
 

--- a/views-react/src/main/java/io/micronaut/views/react/util/BeanPool.java
+++ b/views-react/src/main/java/io/micronaut/views/react/util/BeanPool.java
@@ -18,8 +18,6 @@ package io.micronaut.views.react.util;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.functional.ThrowingFunction;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.lang.ref.SoftReference;
 import java.util.LinkedList;
 import java.util.function.Supplier;
@@ -37,7 +35,7 @@ import java.util.function.Supplier;
  * </p>
  *
  * <p>
- * Beans in the pool can be atomically cleared and closed (if they implement {@link Closeable}).
+ * Beans in the pool can be atomically cleared and closed (if they implement {@link AutoCloseable}).
  * Any beans checked out when {@link #clear()} is called will remain untouched, but when they are
  * checked back in they will be closed and discarded at that point.
  * </p>
@@ -99,7 +97,7 @@ public class BeanPool<T> {
      * Puts a context back into the pool. It should be returned in a 'clean' state, so whatever
      * thread picks it up next finds it ready to use and without any leftover data from prior
      * usages. If the pool has been {@link #clear() cleared} previously, and the pooled object is
-     * {@link Closeable}, then the object will be closed at this point (exceptions are ignored).
+     * {@link AutoCloseable}, then the object will be closed at this point (exceptions are ignored).
      *
      * @param handle The object you got from {@link #checkOut()}.
      */
@@ -108,10 +106,10 @@ public class BeanPool<T> {
         // Put it back into the pool for reuse unless it's out of date, in which case just let it drift.
         if (impl.version == versionCounter) {
             pool.add(new SoftReference<>(impl));
-        } else if (impl.obj instanceof Closeable closeable) {
+        } else if (impl.obj instanceof AutoCloseable closeable) {
             try {
                 closeable.close();
-            } catch (IOException ignored) {
+            } catch (Exception ignored) {
             }
         }
     }
@@ -144,8 +142,8 @@ public class BeanPool<T> {
     /**
      * Empties the pool. Beans currently checked out with {@link #checkOut()} will not be re-added
      * to the pool when {@link #checkIn(Handle)} is called, and may be closed if they are
-     * {@link Closeable}. Likewise, all beans in the pool are closed if they are {@link Closeable}
-     * and exceptions thrown by {@link Closeable#close()} are ignored.
+     * {@link AutoCloseable}. Likewise, all beans in the pool are closed if they are {@link AutoCloseable}
+     * and exceptions thrown by {@link AutoCloseable#close()} are ignored.
      */
     public synchronized void clear() {
         versionCounter++;
@@ -154,10 +152,10 @@ public class BeanPool<T> {
         }
         for (SoftReference<PoolEntry> ref : pool) {
             var r = ref.get();
-            if (r != null && r.obj instanceof Closeable closeable) {
+            if (r != null && r.obj instanceof AutoCloseable closeable) {
                 try {
                     closeable.close();
-                } catch (IOException ignored) {
+                } catch (Exception ignored) {
                 }
             }
         }

--- a/views-react/src/test/groovy/io/micronaut/views/react/BeanPoolSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/BeanPoolSpec.groovy
@@ -1,0 +1,50 @@
+package io.micronaut.views.react
+
+import io.micronaut.views.react.util.BeanPool
+import spock.lang.Specification
+
+import java.io.IOException
+
+class BeanPoolSpec extends Specification {
+
+    void "clear ignores AutoCloseable failures"() {
+        given:
+        AutoCloseable bean = { throw new IOException("expected") } as AutoCloseable
+        BeanPool<AutoCloseable> pool = new BeanPool({ bean })
+        pool.checkIn(pool.checkOut())
+
+        when:
+        pool.clear()
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "clear closes pooled AutoCloseable beans"() {
+        given:
+        AutoCloseable bean = Mock()
+        BeanPool<AutoCloseable> pool = new BeanPool({ bean })
+        def handle = pool.checkOut()
+        pool.checkIn(handle)
+
+        when:
+        pool.clear()
+
+        then:
+        1 * bean.close()
+    }
+
+    void "clear closes checked out AutoCloseable beans when they return"() {
+        given:
+        AutoCloseable bean = Mock()
+        BeanPool<AutoCloseable> pool = new BeanPool({ bean })
+        def handle = pool.checkOut()
+
+        when:
+        pool.clear()
+        pool.checkIn(handle)
+
+        then:
+        1 * bean.close()
+    }
+}

--- a/views-react/src/test/groovy/io/micronaut/views/react/ReactContextProviderSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/ReactContextProviderSpec.groovy
@@ -1,0 +1,46 @@
+package io.micronaut.views.react
+
+import org.graalvm.polyglot.Context
+import org.graalvm.polyglot.Source
+import spock.lang.Specification
+
+class ReactContextProviderSpec extends Specification {
+
+    void "custom providers receive rendering and source invalidation callbacks without owning renderer cache"() {
+        given:
+        Context context = Context.newBuilder("js")
+            .allowAllAccess(true)
+            .option("js.esm-eval-returns-exports", "true")
+            .build()
+        Source serverBundle = Source.newBuilder("js", "export function App() { return null }", "bundle.mjs")
+            .mimeType("application/javascript+module")
+            .build()
+        Source renderScript = Source.newBuilder("js", "export function ssr(component, props, callback) { callback.write('rendered') }", "render.mjs")
+            .mimeType("application/javascript+module")
+            .build()
+        ReactContextProvider provider = Mock()
+        provider.withContext(_) >> { args -> args[0].apply(context) }
+        ReactViewsRendererConfiguration configuration = Stub() {
+            getClientBundleURL() >> "/static/client.js"
+            getServerBundlePath() >> "bundle.mjs"
+            getRenderScript() >> "render.mjs"
+        }
+        ReactJSSources sources = Mock()
+        sources.generation() >> 0L
+        sources.serverBundle() >> serverBundle
+        sources.renderScript() >> renderScript
+        ReactViewsRenderer renderer = new ReactViewsRenderer(provider, configuration, sources)
+
+        when:
+        String result = WritableUtils.writableToString(renderer.render("App", [:], null)).orElseThrow()
+        renderer.onApplicationEvent(new ReactJSSourcesChangedEvent(sources, 1L))
+        context.eval("js", "1")
+
+        then:
+        result == "rendered"
+        1 * provider.sourcesChanged(1L)
+
+        cleanup:
+        context?.close()
+    }
+}

--- a/views-react/src/test/groovy/io/micronaut/views/react/ReactContextProviderSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/ReactContextProviderSpec.groovy
@@ -1,10 +1,75 @@
 package io.micronaut.views.react
 
+import io.micronaut.views.react.util.BeanPool
+import io.micronaut.http.exceptions.MessageBodyException
 import org.graalvm.polyglot.Context
 import org.graalvm.polyglot.Source
 import spock.lang.Specification
 
 class ReactContextProviderSpec extends Specification {
+
+    void "renderer reports a missing SSR function"() {
+        given:
+        Context context = Context.newBuilder("js").option("js.esm-eval-returns-exports", "true").build()
+        ReactViewsRenderer renderer = renderer(context,
+            module("export function App() { return null }", "bundle.mjs"),
+            module("export const other = 1", "render.mjs"))
+
+        when:
+        renderer.render("App", [:], null).writeTo(OutputStream.nullOutputStream())
+
+        then:
+        thrown(MessageBodyException)
+
+        cleanup:
+        context.close()
+    }
+
+    void "renderer reports an unknown component"() {
+        given:
+        Context context = Context.newBuilder("js").option("js.esm-eval-returns-exports", "true").build()
+        ReactViewsRenderer renderer = renderer(context,
+            module("export function Other() { return null }", "bundle.mjs"),
+            module("export function ssr(component, props, callback) { callback.write('rendered') }", "render.mjs"))
+
+        when:
+        renderer.render("App", [:], null).writeTo(OutputStream.nullOutputStream())
+
+        then:
+        thrown(MessageBodyException)
+
+        cleanup:
+        context.close()
+    }
+
+    void "provider source invalidation is optional"() {
+        given:
+        ReactContextProvider provider = { callback -> "result" }
+
+        expect:
+        provider.withContext { "ignored" } == "result"
+        provider.sourcesChanged(1L)
+    }
+
+    void "default provider clears its owned context pool on source changes"() {
+        given:
+        Context context = Context.newBuilder("js").build()
+        BeanPool<ReactJSContext> pool = new BeanPool({ new ReactJSContext(context) })
+        ReactContextProvider provider = new DefaultReactContextProvider(pool)
+
+        expect:
+        provider.withContext { it == context }
+
+        when:
+        provider.sourcesChanged(1L)
+        context.eval("js", "1")
+
+        then:
+        thrown(IllegalStateException)
+
+        cleanup:
+        context.close()
+    }
 
     void "custom providers receive rendering and source invalidation callbacks without owning renderer cache"() {
         given:
@@ -26,21 +91,47 @@ class ReactContextProviderSpec extends Specification {
             getRenderScript() >> "render.mjs"
         }
         ReactJSSources sources = Mock()
-        sources.generation() >> 0L
+        sources.generation() >>> [0L, 1L]
         sources.serverBundle() >> serverBundle
         sources.renderScript() >> renderScript
         ReactViewsRenderer renderer = new ReactViewsRenderer(provider, configuration, sources)
 
         when:
         String result = WritableUtils.writableToString(renderer.render("App", [:], null)).orElseThrow()
+        boolean exists = renderer.exists("App")
+        boolean missing = renderer.exists("Missing")
         renderer.onApplicationEvent(new ReactJSSourcesChangedEvent(sources, 1L))
+        String reloaded = WritableUtils.writableToString(renderer.render("App", [:], null)).orElseThrow()
         context.eval("js", "1")
 
         then:
         result == "rendered"
+        reloaded == "rendered"
+        exists
+        !missing
         1 * provider.sourcesChanged(1L)
 
         cleanup:
         context?.close()
+    }
+
+    private static Source module(String source, String name) {
+        Source.newBuilder("js", source, name)
+            .mimeType("application/javascript+module")
+            .build()
+    }
+
+    private ReactViewsRenderer renderer(Context context, Source serverBundle, Source renderScript) {
+        ReactContextProvider provider = { callback -> callback.apply(context) }
+        ReactViewsRendererConfiguration configuration = Stub() {
+            getClientBundleURL() >> "/static/client.js"
+            getServerBundlePath() >> "bundle.mjs"
+            getRenderScript() >> "render.mjs"
+        }
+        ReactJSSources sources = Mock()
+        sources.generation() >> 0L
+        sources.serverBundle() >> serverBundle
+        sources.renderScript() >> renderScript
+        new ReactViewsRenderer(provider, configuration, sources)
     }
 }

--- a/views-react/src/test/groovy/io/micronaut/views/react/ReactJSSourcesSpec.groovy
+++ b/views-react/src/test/groovy/io/micronaut/views/react/ReactJSSourcesSpec.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.views.react
+
+import io.micronaut.context.event.ApplicationEventPublisher
+import io.micronaut.core.io.ResourceResolver
+import io.micronaut.scheduling.io.watch.event.FileChangedEvent
+import io.micronaut.scheduling.io.watch.event.WatchEventType
+import org.graalvm.polyglot.Source
+import spock.lang.Specification
+
+import java.nio.file.Files
+
+class ReactJSSourcesSpec extends Specification {
+
+    void "source changes invalidate each source and advance the generation"() {
+        given:
+        def file = Files.createTempFile("react-source", ".mjs").toFile()
+        file.text = "export const App = () => null"
+        URL url = file.toURI().toURL()
+        ResourceResolver resolver = Mock()
+        resolver.getResource("bundle") >> Optional.of(url)
+        resolver.getResource("render") >> Optional.of(url)
+        ReactViewsRendererConfiguration configuration = Stub() {
+            getServerBundlePath() >> "bundle"
+            getRenderScript() >> "render"
+        }
+        ApplicationEventPublisher<ReactJSSourcesChangedEvent> publisher = Mock()
+        ReactJSSources sources = new ReactJSSources(resolver, configuration, publisher)
+
+        when:
+        Source server = sources.serverBundle()
+        sources.onApplicationEvent(new FileChangedEvent(serverPath(server), WatchEventType.MODIFY))
+        Source render = sources.renderScript()
+        sources.onApplicationEvent(new FileChangedEvent(serverPath(render), WatchEventType.MODIFY))
+        sources.onApplicationEvent(new FileChangedEvent(serverPath(render), WatchEventType.DELETE))
+
+        then:
+        sources.generation() == 2L
+        2 * publisher.publishEvent(_)
+
+        cleanup:
+        file.delete()
+    }
+
+    private static java.nio.file.Path serverPath(Source source) {
+        return java.nio.file.Paths.get(source.getURI())
+    }
+}


### PR DESCRIPTION
## Summary

- add experimental callback-scoped `ReactContextProvider`
- lazily initialize and cache React bundle state per context and source generation
- preserve the standalone context pool as the default provider
- keep externally owned contexts open during reload and use uniquely named generation sources
- close all `AutoCloseable` pool entries correctly

## Compatibility

Standalone React rendering, sandbox configuration, and `@ReactBean` customization remain the defaults when no custom provider is present. This PR is independently mergeable; the Pyronaut adapter consumes the SPI separately.

## Verification

- `./gradlew :micronaut-views-react:compileJava`
- the exact test task reaches execution, but this machine has GraalVM 25.1.3 while the repository resolves Graal 25.0.3 libgraal artifacts, causing `LibGraalScope.attachThreadTo` before rendering