### PR TITLE
Register Thymeleaf Jackson 3 builder for native images

### DIFF
--- a/views-thymeleaf/src/main/resources/META-INF/native-image/io.micronaut.views/micronaut-views-thymeleaf/reachability-metadata.json
+++ b/views-thymeleaf/src/main/resources/META-INF/native-image/io.micronaut.views/micronaut-views-thymeleaf/reachability-metadata.json
@@ -1,0 +1,13 @@
+{
+  "reflection": [
+    {
+      "type": "tools.jackson.databind.json.JsonMapper",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Thymeleaf 3.1 reflectively discovers Jackson 3 when it serializes JavaScript. Native execution fails with MissingReflectionRegistrationError for tools.jackson.databind.json.JsonMapper.builder(). Add the exact reachability metadata to the Thymeleaf module so applications do not need guide-specific reflection configuration.

Validated with :micronaut-views-thymeleaf:compileJava.